### PR TITLE
feat: PDF 파서를 opendataloader-pdf로 교체 (HWP/기타 인프라 보존)

### DIFF
--- a/pipeline/01_parser.py
+++ b/pipeline/01_parser.py
@@ -92,8 +92,12 @@ def parse_pdf_batch(file_paths):
                 input_path=copied_inputs, output_dir=out_dir, format="markdown"
             )
         except (RuntimeError, OSError, ValueError) as e:
-            print(f"  [PDF 배치 변환 오류] {e}")
-            return results
+            # 배치 변환은 보통 환경 문제(JVM/Java 누락 등)에서 실패한다.
+            # 빈 결과를 silent 하게 저장하면 호출자가 실패 인지 못 하므로 raise.
+            raise RuntimeError(
+                f"opendataloader-pdf 변환 실패 ({len(copied_inputs)}개 PDF). "
+                f"Java 11+ 설치 여부 확인 필요. 원본: {e}"
+            ) from e
 
         for fname in os.listdir(out_dir):
             if not fname.endswith(".md"):
@@ -282,7 +286,9 @@ def parse_zip(file_path):
                 text = parse_docx(inner_path)
 
             if text:
-                result.append(f"[ZIP 내부: {fname}]\n{text}")
+                # ZIP 안에 같은 이름이 다른 디렉터리에 있을 수 있어 상대 경로 사용
+                rel = os.path.relpath(inner_path, tmp_zip_dir)
+                result.append(f"[ZIP 내부: {rel}]\n{text}")
 
     except Exception as e:
         print(f"  [ZIP 오류] {file_path}: {e}")

--- a/pipeline/01_parser.py
+++ b/pipeline/01_parser.py
@@ -5,7 +5,8 @@ import zipfile
 import subprocess
 import shutil
 import platform
-import fitz  # PyMuPDF
+import tempfile
+import opendataloader_pdf
 import pandas as pd
 from docx import Document
 
@@ -51,36 +52,37 @@ def find_libreoffice():
 LIBREOFFICE = find_libreoffice()
 
 
-def parse_pdf(file_path):
-    """PDF에서 텍스트 + 표 추출 (PyMuPDF)"""
-    result = []
-    try:
-        with fitz.open(file_path) as doc:
-            for page in doc:
-                text = page.get_text() or ""
-
-                table_texts = []
+def parse_pdf_batch(file_paths):
+    """opendataloader_pdf로 여러 PDF를 한 번에 Markdown으로 변환.
+    JVM 부팅이 호출당 ~수백ms라 배치가 필수. 반환: dict[절대경로]→markdown 텍스트."""
+    if not file_paths:
+        return {}
+    abs_paths = [os.path.abspath(p) for p in file_paths]
+    results = {p: "" for p in abs_paths}
+    with tempfile.TemporaryDirectory() as tmp:
+        try:
+            opendataloader_pdf.convert(
+                input_path=abs_paths, output_dir=tmp, format="markdown"
+            )
+        except Exception as e:
+            print(f"  [PDF 배치 변환 오류] {e}")
+            return results
+        for p in abs_paths:
+            stem = os.path.splitext(os.path.basename(p))[0]
+            md_path = os.path.join(tmp, stem + ".md")
+            if os.path.exists(md_path):
                 try:
-                    tables = page.find_tables()
-                    for table in tables:
-                        rows = table.extract()
-                        for row in rows:
-                            row_text = " | ".join(
-                                (cell or "").strip() for cell in row
-                            )
-                            if row_text.strip(" |"):
-                                table_texts.append(row_text)
-                except Exception:
-                    pass  # 표 추출 실패해도 본문 텍스트는 살림
+                    with open(md_path, encoding="utf-8") as f:
+                        results[p] = f.read().strip()
+                except Exception as e:
+                    print(f"  [PDF md 읽기 오류] {p}: {e}")
+    return results
 
-                page_content = text
-                if table_texts:
-                    page_content += "\n[표]\n" + "\n".join(table_texts)
-                if page_content.strip():
-                    result.append(page_content.strip())
-    except Exception as e:
-        print(f"  [PDF 오류] {file_path}: {e}")
-    return "\n\n".join(result)
+
+def parse_pdf(file_path):
+    """단일 PDF 파싱. 내부적으로 parse_pdf_batch 호출 (JVM 1회 부팅 비용 발생)."""
+    abs_path = os.path.abspath(file_path)
+    return parse_pdf_batch([abs_path]).get(abs_path, "")
 
 
 def _libreoffice_convert(file_path, fmt, ext):
@@ -213,7 +215,7 @@ def parse_docx(file_path):
 
 
 def parse_zip(file_path):
-    """ZIP 압축 해제 후 내부 파일 파싱"""
+    """ZIP 압축 해제 후 내부 파일 파싱. 내부 PDF는 한 번에 배치 처리."""
     result = []
     tmp_zip_dir = os.path.join(BASE_DIR, "data", "tmp_zip")
     try:
@@ -221,23 +223,28 @@ def parse_zip(file_path):
         with zipfile.ZipFile(file_path, "r") as z:
             z.extractall(tmp_zip_dir)
 
+        # 내부 파일 수집 (확장자별 분류)
+        inner_files = []
         for root, _, files in os.walk(tmp_zip_dir):
             for fname in files:
-                inner_path = os.path.join(root, fname)
-                ext = os.path.splitext(fname)[1].lower()
-                text = ""
+                inner_files.append((fname, os.path.join(root, fname)))
+        pdf_paths = [p for f, p in inner_files if os.path.splitext(f)[1].lower() == ".pdf"]
+        pdf_results = parse_pdf_batch(pdf_paths) if pdf_paths else {}
 
-                if ext == ".pdf":
-                    text = parse_pdf(inner_path)
-                elif ext in [".hwp", ".hwpx"]:
-                    text = parse_hwp(inner_path)
-                elif ext in [".xlsx", ".xls"]:
-                    text = parse_xlsx(inner_path)
-                elif ext == ".docx":
-                    text = parse_docx(inner_path)
+        for fname, inner_path in inner_files:
+            ext = os.path.splitext(fname)[1].lower()
+            text = ""
+            if ext == ".pdf":
+                text = pdf_results.get(os.path.abspath(inner_path), "")
+            elif ext in [".hwp", ".hwpx"]:
+                text = parse_hwp(inner_path)
+            elif ext in [".xlsx", ".xls"]:
+                text = parse_xlsx(inner_path)
+            elif ext == ".docx":
+                text = parse_docx(inner_path)
 
-                if text:
-                    result.append(f"[ZIP 내부: {fname}]\n{text}")
+            if text:
+                result.append(f"[ZIP 내부: {fname}]\n{text}")
 
     except Exception as e:
         print(f"  [ZIP 오류] {file_path}: {e}")
@@ -304,8 +311,36 @@ def parse_all():
     cached_count = 0
     parsed_count = 0
 
+    # PDF 배치 변환을 위해 처리 대상 PDF 경로 먼저 수집
+    pdf_to_process = []
     for notice in notices:
-        wr_id = notice["url"].split("wr_id=")[1].split("&")[0]
+        try:
+            wr_id = notice["url"].split("wr_id=")[1].split("&")[0]
+        except (KeyError, IndexError):
+            continue
+        attach_dir = os.path.join(ATTACHMENT_DIR, wr_id)
+        for att in notice.get("attachments", []):
+            file_name = att["name"]
+            ext = os.path.splitext(file_name)[1].lower()
+            if ext != ".pdf":
+                continue
+            cached = existing.get(wr_id, {}).get(file_name, "")
+            if cached:
+                continue
+            file_path = os.path.join(attach_dir, file_name)
+            if os.path.exists(file_path):
+                pdf_to_process.append(file_path)
+
+    pdf_results = {}
+    if pdf_to_process:
+        print(f"[PDF 배치] {len(pdf_to_process)}개 PDF를 opendataloader로 변환 중...")
+        pdf_results = parse_pdf_batch(pdf_to_process)
+
+    for notice in notices:
+        try:
+            wr_id = notice["url"].split("wr_id=")[1].split("&")[0]
+        except (KeyError, IndexError):
+            continue
         attach_dir = os.path.join(ATTACHMENT_DIR, wr_id)
         attachments = notice.get("attachments", [])
 
@@ -317,6 +352,7 @@ def parse_all():
         for att in attachments:
             file_name = att["name"]
             file_path = os.path.join(attach_dir, file_name)
+            ext = os.path.splitext(file_name)[1].lower()
 
             cached = existing.get(wr_id, {}).get(file_name, "")
             if cached:
@@ -329,8 +365,11 @@ def parse_all():
                 print(f"  [없음] {file_name}")
                 continue
 
-            print(f"  파싱 중: {file_name}")
-            text = parse_file(file_path)
+            if ext == ".pdf":
+                text = pdf_results.get(os.path.abspath(file_path), "")
+            else:
+                print(f"  파싱 중: {file_name}")
+                text = parse_file(file_path)
             att["parsed_text"] = text
             warn_if_empty(file_name, text)
             print(f"  완료: {len(text)}자 추출")
@@ -368,6 +407,18 @@ def parse_manual_files():
     parsed_count = 0
     print(f"[시작] manual_files 파싱")
 
+    # PDF 배치 변환 대상 수집
+    pdf_to_process = []
+    for fname in sorted(os.listdir(manual_dir)):
+        ext = os.path.splitext(fname)[1].lower()
+        if ext == ".pdf" and not (fname in existing and existing[fname]):
+            pdf_to_process.append(os.path.join(manual_dir, fname))
+
+    pdf_results = {}
+    if pdf_to_process:
+        print(f"[PDF 배치] {len(pdf_to_process)}개 PDF를 opendataloader로 변환 중...")
+        pdf_results = parse_pdf_batch(pdf_to_process)
+
     for fname in sorted(os.listdir(manual_dir)):
         fpath = os.path.join(manual_dir, fname)
         ext = os.path.splitext(fname)[1].lower()
@@ -382,11 +433,14 @@ def parse_manual_files():
             cached_count += 1
             continue
 
-        print(f"  파싱 중: {fname}")
-        if ext == ".txt":
+        if ext == ".pdf":
+            text = pdf_results.get(os.path.abspath(fpath), "")
+        elif ext == ".txt":
+            print(f"  파싱 중: {fname}")
             with open(fpath, "r", encoding="utf-8", errors="ignore") as f:
                 text = f.read().strip()
         else:
+            print(f"  파싱 중: {fname}")
             text = parse_file(fpath)
 
         warn_if_empty(fname, text)

--- a/pipeline/01_parser.py
+++ b/pipeline/01_parser.py
@@ -54,28 +54,59 @@ LIBREOFFICE = find_libreoffice()
 
 def parse_pdf_batch(file_paths):
     """opendataloader_pdf로 여러 PDF를 한 번에 Markdown으로 변환.
-    JVM 부팅이 호출당 ~수백ms라 배치가 필수. 반환: dict[절대경로]→markdown 텍스트."""
+    JVM 부팅이 호출당 ~수백ms라 배치가 필수. 반환: dict[절대경로]→markdown 텍스트.
+
+    같은 basename을 가진 PDF가 다른 디렉터리에 있을 수 있으므로 (예: 서로 다른
+    공지의 동명 첨부) 인덱스 prefix를 붙여 입력 디렉터리에 복사한 뒤 변환한다.
+    """
     if not file_paths:
         return {}
     abs_paths = [os.path.abspath(p) for p in file_paths]
     results = {p: "" for p in abs_paths}
     with tempfile.TemporaryDirectory() as tmp:
+        in_dir = os.path.join(tmp, "in")
+        out_dir = os.path.join(tmp, "out")
+        os.makedirs(in_dir)
+        os.makedirs(out_dir)
+
+        # 인덱스 prefix를 붙여 복사 → md 파일 stem으로 원본 경로를 역추적
+        stem_to_orig = {}
+        copied_inputs = []
+        for i, p in enumerate(abs_paths):
+            base = os.path.splitext(os.path.basename(p))[0]
+            new_stem = f"{i:04d}_{base}"
+            new_path = os.path.join(in_dir, new_stem + ".pdf")
+            try:
+                shutil.copyfile(p, new_path)
+            except OSError as e:
+                print(f"  [PDF 복사 실패] {p}: {e}")
+                continue
+            stem_to_orig[new_stem] = p
+            copied_inputs.append(new_path)
+
+        if not copied_inputs:
+            return results
+
         try:
             opendataloader_pdf.convert(
-                input_path=abs_paths, output_dir=tmp, format="markdown"
+                input_path=copied_inputs, output_dir=out_dir, format="markdown"
             )
-        except Exception as e:
+        except (RuntimeError, OSError, ValueError) as e:
             print(f"  [PDF 배치 변환 오류] {e}")
             return results
-        for p in abs_paths:
-            stem = os.path.splitext(os.path.basename(p))[0]
-            md_path = os.path.join(tmp, stem + ".md")
-            if os.path.exists(md_path):
-                try:
-                    with open(md_path, encoding="utf-8") as f:
-                        results[p] = f.read().strip()
-                except Exception as e:
-                    print(f"  [PDF md 읽기 오류] {p}: {e}")
+
+        for fname in os.listdir(out_dir):
+            if not fname.endswith(".md"):
+                continue
+            stem = os.path.splitext(fname)[0]
+            orig = stem_to_orig.get(stem)
+            if not orig:
+                continue
+            try:
+                with open(os.path.join(out_dir, fname), encoding="utf-8") as f:
+                    results[orig] = f.read().strip()
+            except OSError as e:
+                print(f"  [PDF md 읽기 오류] {orig}: {e}")
     return results
 
 
@@ -220,8 +251,15 @@ def parse_zip(file_path):
     tmp_zip_dir = os.path.join(BASE_DIR, "data", "tmp_zip")
     try:
         os.makedirs(tmp_zip_dir, exist_ok=True)
+        # zip-slip 방지: 추출 경로가 base 디렉터리를 벗어나는 엔트리는 거부
+        base_dir = os.path.realpath(tmp_zip_dir) + os.sep
         with zipfile.ZipFile(file_path, "r") as z:
-            z.extractall(tmp_zip_dir)
+            for member in z.infolist():
+                target = os.path.realpath(os.path.join(tmp_zip_dir, member.filename))
+                if not (target + os.sep).startswith(base_dir):
+                    print(f"  [ZIP 위험 엔트리 거부] {member.filename}")
+                    continue
+                z.extract(member, tmp_zip_dir)
 
         # 내부 파일 수집 (확장자별 분류)
         inner_files = []

--- a/pipeline/01_parser.py
+++ b/pipeline/01_parser.py
@@ -458,7 +458,7 @@ def parse_manual_files():
     pdf_to_process = []
     for fname in sorted(os.listdir(manual_dir)):
         ext = os.path.splitext(fname)[1].lower()
-        if ext == ".pdf" and not (fname in existing and existing[fname]):
+        if ext == ".pdf" and not existing.get(fname):
             pdf_to_process.append(os.path.join(manual_dir, fname))
 
     pdf_results = {}
@@ -474,9 +474,10 @@ def parse_manual_files():
             print(f"  [스킵] {fname}")
             continue
 
-        if fname in existing and existing[fname]:
-            print(f"  [캐시] {fname} ({len(existing[fname])}자)")
-            results.append({"file_name": fname, "parsed_text": existing[fname]})
+        cached_text = existing.get(fname)
+        if cached_text:
+            print(f"  [캐시] {fname} ({len(cached_text)}자)")
+            results.append({"file_name": fname, "parsed_text": cached_text})
             cached_count += 1
             continue
 

--- a/pipeline/01_parser.py
+++ b/pipeline/01_parser.py
@@ -76,11 +76,8 @@ def parse_pdf_batch(file_paths):
             base = os.path.splitext(os.path.basename(p))[0]
             new_stem = f"{i:04d}_{base}"
             new_path = os.path.join(in_dir, new_stem + ".pdf")
-            try:
-                shutil.copyfile(p, new_path)
-            except OSError as e:
-                print(f"  [PDF 복사 실패] {p}: {e}")
-                continue
+            # 복사 실패는 환경 문제(권한/디스크 등)이므로 OSError 가 자연스럽게 전파됨
+            shutil.copyfile(p, new_path)
             stem_to_orig[new_stem] = p
             copied_inputs.append(new_path)
 

--- a/pipeline/01_parser.py
+++ b/pipeline/01_parser.py
@@ -290,6 +290,9 @@ def parse_zip(file_path):
                 rel = os.path.relpath(inner_path, tmp_zip_dir)
                 result.append(f"[ZIP 내부: {rel}]\n{text}")
 
+    except RuntimeError:
+        # parse_pdf_batch가 raise한 환경 오류는 상위로 그대로 전파
+        raise
     except Exception as e:
         print(f"  [ZIP 오류] {file_path}: {e}")
     finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.31.0
 beautifulsoup4==4.12.3
-opendataloader-pdf
+opendataloader-pdf==2.4.1
 pyhwp==0.1b15
 
 chromadb==0.6.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 requests==2.31.0
 beautifulsoup4==4.12.3
-pymupdf==1.24.13
+opendataloader-pdf
 pyhwp==0.1b15
 
 chromadb==0.6.3


### PR DESCRIPTION
## 요약
PDF 파싱을 PyMuPDF에서 [opendataloader-pdf](https://github.com/opendataloader-project/opendataloader-pdf)로 교체합니다. PR #13의 의도(opendataloader 도입)는 살리되, main의 PR #9 자산(HWP 3단 fallback, 크로스플랫폼 LibreOffice 탐색 등)은 그대로 유지하는 수술적 변경입니다.

## 변경
- `parse_pdf`: PyMuPDF → opendataloader-pdf (Markdown 출력)
- `parse_pdf_batch` 추가: JVM 부팅 비용 줄이기 위한 배치 변환
- `parse_all` / `parse_manual_files` / `parse_zip`: PDF 경로를 먼저 모아 한 번에 변환
- `requirements.txt`: `pymupdf` 제거, `opendataloader-pdf==2.4.1` 추가

## 보존된 것 (main의 PR #9 자산)
- `parse_hwp` 3단 fallback
- `_libreoffice_convert`, `_hwp5txt_extract` (pyhwp)
- `find_libreoffice` 크로스플랫폼 탐색
- `warn_if_empty`, `_cleanup_tmp`, cp949 stdout 처리

## opendataloader 효과
같은 PDF에서:
| | PyMuPDF | opendataloader |
|---|---|---|
| 표 형식 | `\|`로 join한 평문 + `[표]` 마커 | 표준 Markdown 표 |
| 제목 | 평문 | `# 헤딩` |
| RAG 적합도 | 보통 | 우수 |

## 검증
notices 첨부 55개 기준 **52/55 성공** (이전 49/55):
- PDF 16/16, HWP 27/27, XLSX 3/3, DOCX 1/1, ZIP 5/5
- HWPX 0/3 — 별도 이슈 (LibreOffice가 HWPX 미지원, 직접 파싱 필요)

## 사전 요구사항
**Java 11+** 설치 필요 (opendataloader-pdf는 Java 라이브러리의 Python 래퍼).

## CodeRabbit 후속 (커밋 bb76499)
- PDF basename 충돌: 인덱스 prefix로 회피
- Zip-slip 취약점: realpath 검증으로 base 밖 엔트리 거부
- 광범위 except: 좁힌 예외로 변경
- opendataloader-pdf 버전 고정

## 머지 후 수동 작업
이전 PyMuPDF 결과가 캐시(`data/parsed/notices_parsed.json`)에 남아있으면 새 opendataloader 결과로 갱신되지 않습니다. 한 번만 다음 실행:
1. `data/parsed/notices_parsed.json`의 모든 `parsed_text` 필드 비우기 (또는 파일 삭제)
2. `python pipeline/01_parser.py`

## PR #13과의 관계
PR #13을 대체합니다. PR #13은 main의 HWP 인프라를 함께 제거하는 회귀가 있어 close 권장.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 손상되거나 형식이 올바르지 않은 PDF 처리 중 오류 처리 강화
  * ZIP 내부 파일 추출 시 경로 검증 강화로 보안 취약점(zip-slip) 방지
  * 누락되거나 잘못된 식별값이 있는 공지 항목 건너뛰기 처리 추가

* **개선사항**
  * 다수 PDF를 한 번에 변환하는 일괄 처리로 대규모 파일 처리 성능 및 일관성 향상
  * ZIP 내부 파일 처리 정확도 및 결과 매핑 개선

* **변경**
  * PDF 변환 방식 및 관련 의존성 교체(새로운 PDF 변환 라이브러리로 전환)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->