### PR TITLE
fix: graph_db 품질 저하 원인 3건 (CodeRabbit PR #18 unresolved)

### DIFF
--- a/pipeline/03_graph_db.py
+++ b/pipeline/03_graph_db.py
@@ -49,9 +49,13 @@ _NULL_LIKE_NAMES = {"none", "null", "n/a", "nan", "undefined", "unknown", ""}
 
 
 def normalize_node_name(text) -> str:
-    """노드 이름 정규화. None/null 류 입력은 'Unknown' 으로 거부 (str(None)='None' 같은
-    sentinel 값이 그대로 노드 이름이 되어 graph 가 오염되는 것을 방지)."""
+    """노드 이름 정규화. None/null/비정형 입력은 'Unknown' 으로 거부.
+    dict/list 가 들어오면 str(dict) 결과가 그대로 노드 이름이 되는 것을 방지."""
     if text is None:
+        return "Unknown"
+
+    # str/숫자만 허용. LLM 이 dict/list 를 name 필드에 섞어 반환하는 케이스 방어.
+    if not isinstance(text, (str, int, float)):
         return "Unknown"
 
     text = str(text).strip()

--- a/pipeline/03_graph_db.py
+++ b/pipeline/03_graph_db.py
@@ -1,6 +1,7 @@
 import os
 import re
 import json
+import traceback
 from dotenv import load_dotenv
 from neo4j import GraphDatabase
 from openai import OpenAI
@@ -44,11 +45,19 @@ ALIAS_MAP = {
 PLACEHOLDER_NAMES = {"홍길동"}
 
 
-def normalize_node_name(text: str) -> str:
-    if not text:
+_NULL_LIKE_NAMES = {"none", "null", "n/a", "nan", "undefined", "unknown", ""}
+
+
+def normalize_node_name(text) -> str:
+    """노드 이름 정규화. None/null 류 입력은 'Unknown' 으로 거부 (str(None)='None' 같은
+    sentinel 값이 그대로 노드 이름이 되어 graph 가 오염되는 것을 방지)."""
+    if text is None:
         return "Unknown"
 
     text = str(text).strip()
+    if text.lower() in _NULL_LIKE_NAMES:
+        return "Unknown"
+
     text = re.sub(r"\s+", " ", text)
 
     if text in ALIAS_MAP:
@@ -217,7 +226,12 @@ def extract_entities_and_relations(file_name: str, text: str) -> dict:
         entity_names = set()
 
         for ent in entities:
-            name = normalize_node_name(str(ent.get("name", "")))
+            # LLM 이 가끔 dict 가 아닌 string/list 같은 잘못된 형식을 섞어 반환함.
+            # isinstance 체크 없이 바로 .get() 호출하면 한 개 망가진 항목 때문에
+            # 그 문서의 entity/relation 추출 결과 전체가 폐기됨.
+            if not isinstance(ent, dict):
+                continue
+            name = normalize_node_name(ent.get("name"))
             if not name or name == "Unknown" or should_skip_entity_name(name):
                 continue
 
@@ -228,8 +242,10 @@ def extract_entities_and_relations(file_name: str, text: str) -> dict:
         filtered_relations = []
 
         for rel in relations:
-            from_name = normalize_node_name(str(rel.get("from", "")))
-            to_name = normalize_node_name(str(rel.get("to", "")))
+            if not isinstance(rel, dict):
+                continue
+            from_name = normalize_node_name(rel.get("from"))
+            to_name = normalize_node_name(rel.get("to"))
 
             if should_skip_entity_name(from_name) or should_skip_entity_name(to_name):
                 continue
@@ -245,7 +261,10 @@ def extract_entities_and_relations(file_name: str, text: str) -> dict:
         }
 
     except Exception as e:
-        print(f"  [Upstage 오류] {e}")
+        # silently 빈 결과 반환하면 graph 품질 저하의 원인을 못 찾는다.
+        # 일단 디그레이드 동작은 유지하되, 진단 가능하도록 traceback 남김.
+        print(f"  [추출 오류] {file_name}: {type(e).__name__}: {e}")
+        print(traceback.format_exc())
         return {"entities": [], "relations": []}
 
 


### PR DESCRIPTION
## 요약
머지된 PR #18의 unresolved CodeRabbit 지적 중 graph 품질에 직접 영향 주는 3건을 수정합니다. 새 graph DB를 빌드하기 전에 미리 적용해야 noise/오염 없는 결과를 얻을 수 있습니다.

## 변경 (`pipeline/03_graph_db.py`)

### 1. `normalize_node_name`: None/null 입력이 노드 이름이 되던 문제
- `str(None) = "None"` 이 정규화 통과해서 `"None"`이라는 entity가 graph에 들어감
- `_NULL_LIKE_NAMES` set으로 sentinel 값 (None, "None", "null", "n/a", "nan", "undefined", "unknown", "") 일괄 거부

### 2. `extract_entities_relations`: malformed 항목 1개로 전체 폐기되던 문제
- LLM이 dict가 아닌 string/list를 섞어 반환하면 `.get()`에서 `AttributeError`
- 그 문서의 entity/relation 전체가 outer except로 들어가 빈 결과 반환됨
- `isinstance(ent, dict)` 체크로 잘못된 항목만 skip하고 나머지는 살림

### 3. `except Exception`이 silently 빈 결과 반환하던 문제
- 진짜 원인이 묻혀서 graph 품질 저하 진단 불가능
- 디그레이드 동작은 유지하되 `traceback` 출력으로 진단 가능하게

## 검증
`normalize_node_name` 엣지 케이스 9/9 통과:
`None`, `'None'`, `'null'`, `'n/a'`, `'NaN'`, `''`, `'  '` → 모두 `"Unknown"` 반환
`'졸업요건'` → `'졸업요건'`
`'글솝'` → `'글로벌소프트웨어융합전공'` (기존 ALIAS_MAP 동작 유지)

## 다음 작업과의 관계
이 PR 머지 후:
1. Docker 시작 → Neo4j 실행
2. Graph DB 재빌드 (`python pipeline/03_graph_db.py`) — 깨끗한 entity로 빌드
3. 평가 다시 돌리기 → vector vs hybrid 진짜 비교


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 다양한 형태의 null/무효 값(예: none, null, n/a, nan, undefined, unknown, 빈 문자열 등)을 보다 일관되게 처리하여 값 정규화 강화
  * LLM 출력 파싱 견고성 향상: 비정상 항목을 건너뛰고 관계의 양끝을 정규화해 안전하게 처리
  * 추출 실패 시 예외 유형/메시지 및 전체 트레이스백을 로깅하고, 빈 결과를 반환해 복구성 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->