### PR TITLE
feat: hybrid_rag 노이즈 감소 및 prompt 우선순위 가이드 추가

### DIFF
--- a/pipeline/04_hybrid_rag.py
+++ b/pipeline/04_hybrid_rag.py
@@ -101,6 +101,7 @@ def extract_keywords(query):
 
     for token in cleaned.split():
         token = token.strip()
+        # 한글 2자 미만은 노이즈 (조사 잔재 등). 영숫자는 2자 허용.
         if len(token) < 2:
             continue
         if token in stopwords:
@@ -115,12 +116,40 @@ def extract_keywords(query):
             unique_tokens.append(token)
             seen.add(token)
 
+    # 긴 키워드(고유명사/복합어일 가능성)를 우선해서 graph 매칭 정밀도 향상.
+    # "스타트업" 같은 짧은 일반어보다 "K-스타트업 2025" 같은 specific 토큰을 먼저 사용.
+    unique_tokens.sort(key=lambda t: -len(t))
     return unique_tokens[:5]
 
 
 # ── Graph 검색 ───────────────────────────────────────────
-def graph_search(query, max_nodes_per_keyword=5, max_relations=20):
-    """Neo4j에서 키워드 기반 관계 탐색"""
+def _score_relation(rel, keywords):
+    """질문 키워드와의 매칭 점수. 정확 일치 가중치 부여.
+    낮은 점수의 무관한 관계가 LLM context 의 절반을 차지해 답변 품질을
+    저하시키던 문제를 해결하기 위한 필터링용."""
+    score = 0
+    from_node = rel.get("from", "")
+    to_node = rel.get("to", "")
+    for kw in keywords:
+        if not kw:
+            continue
+        # 양쪽 노드 정확 일치 = 강한 단서
+        if kw == from_node:
+            score += 3
+        elif kw in from_node:
+            score += 1
+        if kw == to_node:
+            score += 3
+        elif kw in to_node:
+            score += 1
+    return score
+
+
+def graph_search(query, max_nodes_per_keyword=5, max_relations=5):
+    """Neo4j에서 키워드 기반 관계 탐색.
+    이전엔 max_relations=20 으로 너무 많은 무관한 관계까지 LLM 에 넘겨 hybrid
+    답변 품질이 vector 단독보다 떨어지던 문제가 있었다.
+    이제 키워드 매칭 점수 상위 5개만 반환."""
     driver = get_neo4j_driver()
     results = []
     seen = set()
@@ -207,7 +236,12 @@ def graph_search(query, max_nodes_per_keyword=5, max_relations=20):
                         seen.add(key)
 
     driver.close()
-    return results[:max_relations]
+
+    # 키워드 매칭 점수가 0 인 관계는 노이즈로 보고 제거, 그 외는 점수순 정렬.
+    scored = [(r, _score_relation(r, keywords)) for r in results]
+    scored = [(r, s) for r, s in scored if s > 0]
+    scored.sort(key=lambda x: -x[1])
+    return [r for r, _ in scored[:max_relations]]
 
 
 # ── 결과 통합 ─────────────────────────────────────────────
@@ -238,7 +272,11 @@ def generate_answer(query, context, model="solar-pro"):
     if not context.strip():
         return "해당 정보를 찾을 수 없습니다."
     prompt = f"""당신은 경북대학교 컴퓨터학부 학생들을 위한 AI 챗봇입니다.
-아래 검색된 문서 내용과 그래프 관계 정보를 바탕으로 질문에 답변하세요.
+
+아래 검색 결과를 바탕으로 질문에 답변하세요. 검색 결과는 두 가지로 구성됩니다:
+- [문서 검색 결과]: 공지/문서의 실제 본문. **답변의 주된 근거**로 사용하세요.
+- [관계 그래프 검색 결과]: 개체 간 관계 단서. 보조 정보로만 사용하고, 본문과 모순되거나 본문에 직접적인 답이 있으면 본문을 우선하세요.
+
 반드시 검색 결과에 근거해서만 답변하세요.
 검색 결과에 없는 내용은 추측하지 말고 "해당 정보를 찾을 수 없습니다."라고 답변하세요.
 


### PR DESCRIPTION
## 요약
평가에서 vector 단독이 hybrid보다 더 좋게 나오던 주요 원인을 해결합니다. graph 검색이 무관한 triple 20개를 LLM context에 채워 답변 품질을 떨어뜨리던 문제를 점수 기반 필터링으로 풉니다.

## 변경 (`pipeline/04_hybrid_rag.py`)

1. **`graph_search` `max_relations` 20 → 5** — 즉시 노이즈 75% 감소
2. **`_score_relation` 도입** — 키워드 정확 일치 3점, 부분 일치 1점. 점수 0인 무관한 triple은 필터링, 나머지는 점수순 정렬 후 top-5
3. **`extract_keywords` 길이 우선 정렬** — "스타트업" 같은 짧은 일반어보다 "K-스타트업 2025" 같은 specific 토큰을 먼저 매칭에 사용
4. **`generate_answer` prompt 가이드 추가** — 문서 검색 결과가 주된 근거, 관계 그래프는 보조 정보. 본문에 직접 답이 있으면 본문 우선

## 검증
- `extract_keywords` 길이순 정렬 OK
- `_score_relation` 단위 테스트:
  - K-스타트업 2025→예비창업리그 = 5점 (강한 매치)
  - 스타트업 창업→사업자등록증 = 1점 (약한 매치)
  - 졸업요건→학점 = 0점 (필터링됨)
- `graph_search` 기본 `max_relations=5`

## 다음 단계
1. 본 PR 머지
2. Graph DB 재빌드 (현재 진행 중)
3. 평가 다시 실행 → vector vs hybrid 비교


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 검색 결과 순위 지정 강화로 관련성 높은 결과를 우선 제공합니다.
  * 답변 생성 시 검색 결과 구조를 명확히 개선하여 가독성을 높였습니다.
  * 키워드 추출 로직을 최적화하여 검색 정확도를 향상시켰습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->