### PR TITLE
fix: graph_db Windows cp949 콘솔 인코딩 대응

### DIFF
--- a/pipeline/03_graph_db.py
+++ b/pipeline/03_graph_db.py
@@ -1,10 +1,20 @@
 import os
 import re
+import sys
 import json
 import traceback
 from dotenv import load_dotenv
 from neo4j import GraphDatabase
 from openai import OpenAI
+
+# Windows 콘솔(cp949) 에서도 한글 / em-dash 등 유니코드 출력 안전하게.
+# parser 와 동일한 처리 — 이게 없으면 print 한 줄에서 UnicodeEncodeError 로
+# 빌드 전체가 즉시 죽는다.
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ENV_PATH = os.path.join(BASE_DIR, ".env")


### PR DESCRIPTION
## 문제
`build_graph()`의 첫 `print` 문에 em-dash (`—`, U+2014)가 들어있어 Windows cp949 콘솔에서 `UnicodeEncodeError`로 LLM 호출 한 번도 못 해보고 빌드가 즉시 죽음.

## 변경
parser와 동일한 `sys.stdout.reconfigure(encoding="utf-8")` 블록 추가.

## 검증
- import OK
- em-dash + 한글 print OK
- 빌드 재실행 진행 중


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 버그 수정
  * Windows 환경에서 발생하는 유니코드 인코딩 오류를 해결하여 프로그램의 안정성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->