### PR TITLE
fix: Upstage 모델명 정정 (no hyphen) + Chroma v0.6 호환

### DIFF
--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -27,9 +27,9 @@ def _get_eval_metadata() -> dict:
     """평가 재현성을 위한 모델/하이퍼파라미터/git hash 메타데이터.
     값이 바뀌면 여기 직접 갱신 (런타임 동적 import 보다 단순/명시적이 낫다)."""
     return {
-        "Generation 모델":  "solar-pro-3",
+        "Generation 모델":  "solar-pro3",
         "Generation temp":  "0.2",
-        "Judge 모델":       f"{os.getenv('EVAL_JUDGE_MODEL', 'solar-pro-2')} (temp=0)",
+        "Judge 모델":       f"{os.getenv('EVAL_JUDGE_MODEL', 'solar-pro2')} (temp=0)",
         "Embedding 모델":   "embedding-passage",
         "chunk_size":       "500 (실측)",
         "max_relations":    "5",
@@ -320,13 +320,13 @@ def truncate_text(text, limit=1500):
 
 
 # ── LLM-as-judge: 답변 정답 여부 채점 ─────────────────────
-JUDGE_MODEL = "solar-pro-2"  # 재현성을 위해 generation 과 다른 dated 모델 고정
+JUDGE_MODEL = "solar-pro2"  # 재현성을 위해 generation 과 다른 dated 모델 고정
 JUDGE_TEMPERATURE = 0
 JUDGE_BASE_URL = "https://api.upstage.ai/v1"
 
 
 def get_judge_llm():
-    """채점용 클라이언트 (Upstage solar-pro-2, OpenAI SDK 호환 endpoint).
+    """채점용 클라이언트 (Upstage solar-pro2, OpenAI SDK 호환 endpoint).
     환경변수 EVAL_JUDGE_MODEL 로 모델 변경 가능."""
     from openai import OpenAI
     api_key = os.getenv("UPSTAGE_API_KEY")

--- a/evaluation/evaluate_all_models.py
+++ b/evaluation/evaluate_all_models.py
@@ -49,9 +49,9 @@ def _get_eval_metadata() -> dict:
     """평가 재현성을 위한 모델/하이퍼파라미터/git hash 메타데이터.
     값이 바뀌면 여기 직접 갱신 (런타임 동적 import 보다 단순/명시적이 낫다)."""
     return {
-        "Generation 모델":  "solar-pro-3",
+        "Generation 모델":  "solar-pro3",
         "Generation temp":  "0.2",
-        "Judge 모델":       f"{os.getenv('EVAL_JUDGE_MODEL', 'solar-pro-2')} (temp=0)",
+        "Judge 모델":       f"{os.getenv('EVAL_JUDGE_MODEL', 'solar-pro2')} (temp=0)",
         "Embedding 모델":   "embedding-passage",
         "chunk_size":       "500 (실측)",
         "max_relations":    "5",
@@ -435,13 +435,13 @@ def summarize_graph_relations(graph_relations, max_preview=10):
 
 
 # ── LLM-as-judge: 답변 정답 여부 채점 ─────────────────────
-JUDGE_MODEL = "solar-pro-2"  # 재현성을 위해 generation 과 다른 dated 모델 고정
+JUDGE_MODEL = "solar-pro2"  # 재현성을 위해 generation 과 다른 dated 모델 고정
 JUDGE_TEMPERATURE = 0
 JUDGE_BASE_URL = "https://api.upstage.ai/v1"
 
 
 def get_judge_llm():
-    """채점용 클라이언트 (Upstage solar-pro-2, OpenAI SDK 호환 endpoint).
+    """채점용 클라이언트 (Upstage solar-pro2, OpenAI SDK 호환 endpoint).
     환경변수 EVAL_JUDGE_MODEL 로 모델 변경 가능."""
     from openai import OpenAI
     api_key = os.getenv("UPSTAGE_API_KEY")

--- a/pipeline/02_vector_db.py
+++ b/pipeline/02_vector_db.py
@@ -17,7 +17,7 @@ NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "password1234")
 UPSTAGE_API_KEY = os.getenv("UPSTAGE_API_KEY")
 
 upstage_client = OpenAI(api_key=UPSTAGE_API_KEY, base_url="https://api.upstage.ai/v1")
-EXTRACT_MODEL = "solar-pro-3"   # 개체·관계 추출 및 노드 통합에 사용
+EXTRACT_MODEL = "solar-pro3"   # 개체·관계 추출 및 노드 통합에 사용
 
 
 def get_driver():

--- a/pipeline/03_graph_db.py
+++ b/pipeline/03_graph_db.py
@@ -28,7 +28,7 @@ NEO4J_PASSWORD = os.getenv("NEO4J_PASSWORD", "password1234")
 UPSTAGE_API_KEY = os.getenv("UPSTAGE_API_KEY")
 
 upstage_client = OpenAI(api_key=UPSTAGE_API_KEY, base_url="https://api.upstage.ai/v1")
-EXTRACT_MODEL = "solar-pro-3"   # 개체·관계 추출 및 노드 통합에 사용
+EXTRACT_MODEL = "solar-pro3"   # 개체·관계 추출 및 노드 통합에 사용
 
 
 def get_driver():

--- a/pipeline/04_hybrid_rag.py
+++ b/pipeline/04_hybrid_rag.py
@@ -53,10 +53,9 @@ def vector_search(query, n_results=3):
     embedding_fn = get_embedding_function()
     client = get_chroma_client()
 
-    existing_collections = [
-    c.name if hasattr(c, 'name') else c
-    for c in client.list_collections()
-    ]
+    # Chroma v0.6 부터 list_collections() 가 collection name 문자열만 반환.
+    # 이전 코드의 c.name 접근은 NotImplementedError 를 raise.
+    existing_collections = list(client.list_collections())
     if COLLECTION_NAME not in existing_collections:
         raise ValueError(
             f"컬렉션이 없습니다: {COLLECTION_NAME} | 현재 컬렉션: {existing_collections}"
@@ -267,9 +266,9 @@ def merge_results(vector_docs, graph_relations):
 
 
 # ── LLM 답변 생성 ─────────────────────────────────────────
-GENERATION_MODEL = "solar-pro-3"  # 단일 source of truth — 호출부에서 이 상수 참조
+GENERATION_MODEL = "solar-pro3"  # 단일 source of truth — 호출부에서 이 상수 참조
 GENERATION_TEMPERATURE = 0.2     # 논문 기록용 (낮은 값으로 결정성/재현성 우선)
-GENERATION_MAX_TOKENS = None     # None=모델 기본값 (solar-pro-3 ~ 4k), 정수면 cap
+GENERATION_MAX_TOKENS = None     # None=모델 기본값 (solar-pro3 ~ 4k), 정수면 cap
 
 
 def generate_answer(query, context, model=GENERATION_MODEL):


### PR DESCRIPTION
평가 framework smoke test 에서 발견된 2가지 차단 이슈 fix.

1. Upstage 모델 endpoint 정정: solar-pro-3 / solar-pro-2 가 invalid 였음. 실제 엔드포인트는 hyphen 없이 solar-pro3 / solar-pro2. 직접 API 호출 검증으로 확정 (solar-pro2 ✓, solar-pro-2 ✗).

2. pipeline/04_hybrid_rag.py vector_search: Chroma v0.6 의 list_collections() 는 collection name 문자열만 반환하는데, 기존 코드의 c.name 접근이 NotImplementedError 를 raise 시켜 vector pipeline 전체 실패. list() 변환만으로 해결.

검증 (smoke test 2 질문):
- Vector / Hybrid 답변 생성 OK
- Judge (solar-pro2) 정상 채점, 한국어 reason 출력
- 평가 framework 자체 정상 작동

## 🎯 작업 내용



## 📝 변경 사항



## 🔗 관련 이슈



## ✅ 체크리스트
- [ ] 코드가 컨벤션을 따르고 있나요?
- [ ] 불필요한 콘솔 로그를 제거했나요?
- [ ] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * Chroma 컬렉션 처리 로직 개선

* **Chores**
  * 모델 식별자 업데이트로 시스템 일관성 향상

변경 사항: 5개 파일에서 모델 식별자가 표준화되었으며, 벡터 데이터베이스의 컬렉션 처리 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->