### PR TITLE
feat: graph_db 가 manual + notices attachments 모두 처리 (+ 2-hop ablation 기록)

### DIFF
--- a/docs/ablation-2hop.md
+++ b/docs/ablation-2hop.md
@@ -1,0 +1,66 @@
+# Ablation: 2-hop graph search + 후보 노드 확대
+
+## 가설
+- Graph 검색의 평균 매칭 수가 2.74 / 5 (cap의 절반) → recall 부족이 hybrid 한계의 주된 원인이라 판단
+- 2-hop 간접 관계 + 후보 노드 확대로 recall 을 늘리면 hybrid 정답률이 의미 있게 상승할 것
+
+## 변경 내용 (`pipeline/04_hybrid_rag.py`)
+
+| 항목 | 이전 (1-hop) | 실험 (2-hop + 확대) |
+|---|---|---|
+| graph 탐색 깊이 | 1-hop 정/역방향 | 1-hop + 2-hop 간접 관계 |
+| `max_nodes_per_keyword` | 5 | 10 |
+| 2-hop 점수 가중치 | — | 0.5 (1-hop의 절반) |
+| `merge_results` | 평문 | `(간접)` 마커 추가 |
+| `max_relations` (top-k) | 5 | 5 (동일) |
+
+## 결과
+
+110 질문 평가 (`pipeline/04_hybrid_rag.py` 기반, judge: solar-pro2 temp=0).
+
+| 지표 | 1-hop (이전 베스트) | **2-hop + 확대 (실험)** | 변화 |
+|---|---|---|---|
+| Vector 정답 | 50 / 110 (45.5%) | 53 / 110 (48.2%) | +3 (judge 노이즈 추정) |
+| **Hybrid 정답** | **52 / 110 (47.3%)** | **49 / 110 (44.5%)** | **−3 (악화)** |
+| 평균 graph 매칭 | 2.74 | 2.70 | 거의 동일 |
+| 소요 시간 | 41 분 | **228 분 (3.8 시간)** | **5.6 배** |
+| pipeline error | 0 | 1 (Neo4j timeout 추정) | + |
+
+결과 파일:
+- 1-hop: `evaluation/results/evaluation_results_20260505_201739.{json,xlsx}`
+- 2-hop: `evaluation/results/evaluation_results_20260506_001344.{json,xlsx}`
+
+## 해석
+
+1. **Hybrid 정답률 −3** — 2-hop 간접 관계가 noise 만 추가, 핵심 사실 보강에 도움이 안 됐다
+2. **평균 graph 매칭이 거의 동일 (2.70 vs 2.74)** — 2-hop 관계가 0.5 점수 페널티 때문에 top-5 안에 거의 못 들어감. 결국 1-hop top-5 와 비슷한 결과
+3. **시간 5.6 배 증가** — 2-hop Cypher (`MATCH (a)-[*2..2]-(b)` + 후속 edge 조회) 가 노드당 추가 query 라 비용 큼
+4. **Vector 정답률 +3 변동** — 같은 vector pipeline 인데도 변동 → judge LLM 의 boundary case 미세 변동 추정 (temperature=0 이지만 완전 결정적 아님)
+
+## 결론
+
+**2-hop + 후보 노드 확대는 본 데이터에서 효과 없음 또는 음의 효과.**
+- 정답률 −3, 시간 ×5.6, 비용 증가
+- 1-hop 직접 관계만으로 충분 (오히려 더 정확)
+- recall 확대보다 precision 유지가 더 중요한 데이터 특성으로 보임
+
+→ **main 은 1-hop 유지** (`pipeline/04_hybrid_rag.py` `graph_search` 의 직접 정/역방향 + `max_nodes_per_keyword=5`).
+
+## Paper 활용 포인트
+
+- "graph search 깊이는 1-hop 으로 충분" 을 ablation 으로 정직하게 보고 가능
+- "2-hop 도입은 정답률 −2.7%p, 응답시간 +460% 로 trade-off 가 나쁨" 인용 가능
+- recall 확대 보다 정확한 1-hop 매칭 + 점수 기반 필터링이 본 도메인에 맞다는 근거
+
+## 재현 정보
+
+- Model
+  - Generation: `solar-pro3` (temperature=0.2)
+  - Judge: `solar-pro2` (temperature=0)
+  - Embedding: `embedding-passage`
+- Graph DB: 748 노드 / 1498 관계 (manual 16 + notices 52 attachments)
+- Vector DB (Chroma): `knu_cse_upstage_pro` 컬렉션, 185 chunks, chunk_size=500
+- Branch (실험): `feat/graph-search-2hop` (commit `ad22454`) — 머지하지 않음
+- Branch (롤백 = baseline): `main`
+- 평가 데이터: `evaluation/qa_dataset.json` (110 문항)
+- 평가일: 2026-05-05 ~ 2026-05-06

--- a/pipeline/03_graph_db.py
+++ b/pipeline/03_graph_db.py
@@ -446,25 +446,57 @@ def create_relation(session, from_name: str, to_name: str, rel_type: str):
 
 def build_graph():
     """전체 그래프 구축
-    1단계: solar-pro로 각 문서에서 개체·관계 동적 추출
-    2단계: solar-pro로 전체 노드에서 유사 노드 통합 (1차 배치 + 2차 교차통합)
+    1단계: solar-pro 로 각 문서에서 개체·관계 동적 추출
+    2단계: solar-pro 로 전체 노드에서 유사 노드 통합 (1차 배치 + 2차 교차통합)
     3단계: Neo4j 저장 (Document 노드 + MENTIONS 관계 포함)
+
+    데이터 소스: manual_files + notices 의 attachments (둘 다 평가 대상이라
+    한쪽만 처리하면 hybrid 가 vector 를 보완 못 함).
     """
     manual_path = os.path.join(PARSED_DIR, "manual_parsed.json")
+    notices_path = os.path.join(PARSED_DIR, "notices_parsed.json")
 
-    if not os.path.exists(manual_path):
-        print(f"[오류] 파일이 없습니다: {manual_path}")
+    files_to_process = []
+
+    # 매뉴얼 파일들
+    if os.path.exists(manual_path):
+        with open(manual_path, encoding="utf-8") as f:
+            for mf in json.load(f):
+                files_to_process.append({
+                    "file_name": mf.get("file_name", "unknown"),
+                    "parsed_text": str(mf.get("parsed_text", "")).strip(),
+                })
+    else:
+        print(f"[경고] manual_parsed.json 없음 — 매뉴얼 스킵")
+
+    # 공지 첨부파일들 (각 attachment 를 개별 문서로 처리)
+    if os.path.exists(notices_path):
+        with open(notices_path, encoding="utf-8") as f:
+            for notice in json.load(f):
+                title = (notice.get("title") or "").strip()[:40]
+                for att in notice.get("attachments", []):
+                    text = str(att.get("parsed_text", "")).strip()
+                    if not text:
+                        continue
+                    files_to_process.append({
+                        "file_name": f"[공지] {title} | {att.get('name', '')}",
+                        "parsed_text": text,
+                    })
+    else:
+        print(f"[경고] notices_parsed.json 없음 — 공지 첨부 스킵")
+
+    manual_files = files_to_process  # 기존 변수명 유지 (이후 코드 수정 최소화)
+
+    if not manual_files:
+        print(f"[오류] 처리할 파일 없음")
         return
-
-    with open(manual_path, encoding="utf-8") as f:
-        manual_files = json.load(f)
 
     driver = get_driver()
 
     try:
         clear_db(driver)
 
-        print(f"[시작] Graph DB 구축 ({len(manual_files)}개 파일) — solar-pro 동적 추출 모드")
+        print(f"[시작] Graph DB 구축 ({len(manual_files)}개 파일) — solar-pro3 동적 추출 모드")
 
         all_entity_names = []
         extraction_results = []


### PR DESCRIPTION
## 요약
hybrid 가 vector 보다 못 나오던 문제(평가 결과 vector 50/110 vs hybrid 46/110)의 root cause 가 graph DB 의 데이터 범위 부족임을 확인하고 수정. notices 의 attachments 도 graph 에 포함시켜 hybrid 가 처음으로 vector 를 앞섬.

## 변경
1. **`pipeline/03_graph_db.py`** — `build_graph()` 가 `manual_parsed.json` 만 처리하던 것을 `notices_parsed.json` 의 attachments 까지 처리하도록 확장
   - 처리 대상: 16 docs → **68 docs** (4.25 배)
   - Graph DB: 203 노드 / 466 관계 → **748 노드 / 1498 관계** (3.7 배)

2. **`docs/ablation-2hop.md`** — 2-hop graph search 시도가 음의 효과 (정답률 −3, 시간 +460%) 였던 ablation 결과 기록. main 은 1-hop 유지 결정 근거 + 재현 정보 포함.

## 평가 결과 (single model `upstage_pro`, 110 질문, judge: solar-pro2 temp=0)

| 단계 | Vector 정답 | Hybrid 정답 | 비고 |
|---|---|---|---|
| 이전 (manual only graph) | 50 / 110 (45.5%) | 46 / 110 (41.8%) | hybrid < vector 🔴 |
| **현재 (notices 포함, 1-hop)** | **50 / 110 (45.5%)** | **52 / 110 (47.3%)** | **hybrid > vector ✅ (+1.8%p)** |
| 시도 (2-hop, 후보 10) — rejected | 53 / 110 (48.2%) | 49 / 110 (44.5%) | 시간 5.6 배, 정답률 −3 |

→ Graph scope 확대가 hybrid 효과의 가장 큰 lever. 2-hop 추가는 trade-off 가 나빠 폐기.

## 부수 효과
- Graph 빌드 시간: 25 분 → 40 분 (LLM 호출 4 배)
- 평가 시간: 25.5 분 → 41 분 (graph_search 가 더 큰 그래프 탐색)
- 비용 증가 ~$3-5 (1-회성 graph 빌드)

## 다음 작업 (별 PR)
- [ ] 6 모델 풀 평가로 검증 (현재는 upstage_pro 단일)
- [ ] graph search precision 개선 (예: 키워드 정규화, 동의어 처리)
