### PR TITLE
fix(eval): sanitize Excel formula prefix in xlsx output

### DIFF
--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -188,11 +188,12 @@ def _save_clean_xlsx(xlsx_path, rows, collection_name, experiment_id, elapsed, t
         ]
 
         for col_idx, val in enumerate(data, start=1):
-            cell = ws2.cell(row=idx, column=col_idx, value=val)
+            safe_val = _xlsx_safe(val)
+            cell = ws2.cell(row=idx, column=col_idx, value=safe_val)
             cell.font = N_FONT
 
             if col_idx in SUCCESS_COLS:
-                cell.fill      = SUCCESS_FILL if val == "정답" else FAIL_FILL
+                cell.fill      = SUCCESS_FILL if safe_val == "정답" else FAIL_FILL
                 cell.alignment = AL_TC
             elif col_idx == 4:  # 질문 열 배경
                 cell.fill      = Q_FILL
@@ -213,13 +214,28 @@ def _save_clean_xlsx(xlsx_path, rows, collection_name, experiment_id, elapsed, t
     wb.save(xlsx_path)
 
 
+# 문자열이 이 문자로 시작하면 Excel 이 수식(formula)으로 해석해 #NAME? 등 오류 발생.
+# 시각적으로 거의 동일한 전각/대체 문자로 leading char 만 치환.
+_FORMULA_PREFIX_MAP = {
+    "=": "＝",  # 전각 등호
+    "+": "＋",  # 전각 플러스
+    "-": "－",  # 전각 하이픈-마이너스
+    "@": "＠",  # 전각 골뱅이
+}
+
+
 def _xlsx_safe(val):
-    """openpyxl 이 거부하는 control character 제거.
-    raw context/answer 에 LLM 이 넣은 illegal char (예: \\x00) 를 sanitize."""
+    """openpyxl 이 거부하는 control character 제거 + Excel 수식 prefix 회피.
+    1) raw context/answer 에 LLM 이 넣은 illegal char (예: \\x00) sanitize
+    2) 문자열이 =,+,-,@ 로 시작하면 leading char 를 전각 대체 문자로 치환
+       (LLM 이 '- 항목1' 식 불릿으로 답하면 Excel 이 수식 처리해 깨짐)"""
     if not isinstance(val, str):
         return val
     from openpyxl.cell.cell import ILLEGAL_CHARACTERS_RE
-    return ILLEGAL_CHARACTERS_RE.sub("", val)
+    val = ILLEGAL_CHARACTERS_RE.sub("", val)
+    if val and val[0] in _FORMULA_PREFIX_MAP:
+        val = _FORMULA_PREFIX_MAP[val[0]] + val[1:]
+    return val
 
 
 def _add_detail_sheet(wb, rows, H_FONT, B_FONT, N_FONT, AL_C, AL_TL, AL_TC,


### PR DESCRIPTION
LLM 답변이 '-'로 시작하는 불릿 리스트일 때 Excel 이 수식으로 해석해
#NAME? 오류로 깨지는 문제 수정. =, +, -, @ 로 시작하는 leading char 만 시각적으로 동일한 전각 문자(＝, ＋, －, ＠)로 치환.

- _xlsx_safe 에 formula prefix 치환 로직 추가 (기존 control char 제거 유지)
- ② 결과 시트 data write 에도 _xlsx_safe 적용 (이전엔 ③ 세부지표만)
- ① 요약의 의도된 수식(=COUNTIF 등)은 직접 write 라 영향 없음

## 🎯 작업 내용



## 📝 변경 사항



## 🔗 관련 이슈



## ✅ 체크리스트
- [ ] 코드가 컨벤션을 따르고 있나요?
- [ ] 불필요한 콘솔 로그를 제거했나요?
- [ ] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Excel 평가 결과 파일 생성 시 불법 제어 문자를 제거하여 파일 손상이나 생성 오류 방지
- 등호(=), 더하기(+), 빼기(-), `@기호` 등 특수 문자로 시작하는 셀 값이 부정확한 수식으로 해석되어 오류가 발생하는 문제 제거
- 평가 결과의 성공/실패 상태 색상 표시 로직의 정확도 및 안정성 향상으로 더욱 신뢰할 수 있는 결과 제공

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Capstone1-team6/CapstoneDesign_6/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->