### PR TITLE
fix(front): add @types/node + tsconfig.node types for Linux docker build

### DIFF
--- a/front/Dockerfile
+++ b/front/Dockerfile
@@ -2,8 +2,11 @@ FROM node:20-alpine AS build
 
 WORKDIR /app
 
+# Force dev dependencies (tsc, vite) even if NODE_ENV=production is set
+ENV NODE_ENV=development
+
 COPY front/package*.json ./
-RUN npm ci
+RUN npm ci --include=dev
 
 COPY front ./
 RUN npm run build

--- a/front/package-lock.json
+++ b/front/package-lock.json
@@ -18,6 +18,7 @@
         "zustand": "^4.5.5"
       },
       "devDependencies": {
+        "@types/node": "^20.19.41",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.3",
@@ -1251,6 +1252,16 @@
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.41",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
+      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -4232,6 +4243,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",

--- a/front/package.json
+++ b/front/package.json
@@ -11,16 +11,17 @@
     "typecheck": "tsc -b --noEmit"
   },
   "dependencies": {
+    "axios": "^1.7.7",
+    "clsx": "^2.1.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "zustand": "^4.5.5",
-    "axios": "^1.7.7",
     "react-markdown": "^9.0.1",
-    "remark-gfm": "^4.0.0",
     "rehype-sanitize": "^6.0.0",
-    "clsx": "^2.1.1"
+    "remark-gfm": "^4.0.0",
+    "zustand": "^4.5.5"
   },
   "devDependencies": {
+    "@types/node": "^20.19.41",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.3",

--- a/front/tsconfig.node.json
+++ b/front/tsconfig.node.json
@@ -9,7 +9,8 @@
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true,
     "strict": true,
-    "noEmit": true
+    "noEmit": true,
+    "types": ["node"]
   },
   "include": [
     "vite.config.ts"


### PR DESCRIPTION
원인: tsconfig.node.json 에 @types/node 미참조 → Linux npm ci 가 lockfile 엄격하게 따르면서 vite.config.ts 의 node:path/__dirname 타입 누락으로 TS2307/TS2304 빌드 실패.

- @types/node ^20 devDependency 추가
- tsconfig.node.json compilerOptions.types: ["node"]
- Dockerfile: npm ci --include=dev + ENV NODE_ENV=development (방어적 — NODE_ENV=production 환경에서도 dev deps 보장)

## 🎯 작업 내용



## 📝 변경 사항



## 🔗 관련 이슈



## ✅ 체크리스트
- [ ] 코드가 컨벤션을 따르고 있나요?
- [ ] 불필요한 콘솔 로그를 제거했나요?
- [ ] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (선택)
