### PR TITLE
fix(deploy): remove NEO4J_USER/PASSWORD env from neo4j service (5.x s…

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -6,16 +6,17 @@ services:
     ports:
       - "${NEO4J_HTTP_PORT:-7474}:7474"
       - "${NEO4J_BOLT_PORT:-7687}:7687"
+    # Neo4j 5.x: NEO4J_ 접두사 env var 는 모두 config key 로 해석되므로
+    # NEO4J_AUTH / NEO4J_PLUGINS 같은 공식 변수만 전달.
+    # 인증정보는 compose 변수치환으로 healthcheck 안에 직접 박는다.
     environment:
       NEO4J_AUTH: "${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:-password1234}"
-      NEO4J_USER: "${NEO4J_USER:-neo4j}"
-      NEO4J_PASSWORD: "${NEO4J_PASSWORD:-password1234}"
       NEO4J_PLUGINS: '["apoc"]'
     volumes:
       - neo4j_data:/data
       - neo4j_logs:/logs
     healthcheck:
-      test: ["CMD-SHELL", "cypher-shell -u $$NEO4J_USER -p $$NEO4J_PASSWORD 'RETURN 1' >/dev/null 2>&1"]
+      test: ["CMD-SHELL", "cypher-shell -u ${NEO4J_USER:-neo4j} -p ${NEO4J_PASSWORD:-password1234} 'RETURN 1' >/dev/null 2>&1"]
       interval: 15s
       timeout: 5s
       retries: 20


### PR DESCRIPTION
…trict config)

원인: Neo4j 5.x 는 NEO4J_ 접두사 환경변수를 모두 config key 로 해석. NEO4J_USER → setting 'USER', NEO4J_PASSWORD → setting 'PASSWORD' 로 잡혀 strict_validation 실패 → 컨테이너 무한 재시작 → healthcheck unhealthy.

수정:
- neo4j service environment 에서 NEO4J_USER/NEO4J_PASSWORD 제거 (NEO4J_AUTH 와 NEO4J_PLUGINS 만 공식 지원)
- healthcheck 의 인증정보는 compose 변수치환($)으로 직접 박아 컨테이너 내부 env 의존을 끊음

backend service 의 NEO4J_USER/PASSWORD 는 Python 코드가 읽는 일반 env 이므로 유지.

## 🎯 작업 내용



## 📝 변경 사항



## 🔗 관련 이슈



## ✅ 체크리스트
- [ ] 코드가 컨벤션을 따르고 있나요?
- [ ] 불필요한 콘솔 로그를 제거했나요?
- [ ] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (선택)
