### PR TITLE
feat: 데이터 수집 모니터링 대시보드 + 검색 과정 확인 패널

### DIFF
--- a/backend/app/db/database.py
+++ b/backend/app/db/database.py
@@ -30,6 +30,7 @@ def _ensure_message_columns() -> None:
     columns = {
         "graph_json": "TEXT",
         "followups_json": "TEXT",
+        "retrieval_json": "TEXT",
     }
     missing = [(name, ddl_type) for name, ddl_type in columns.items() if name not in existing]
     if not missing:

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -19,5 +19,7 @@ class Message(SQLModel, table=True):
     sources_json: Optional[str] = None
     graph_json: Optional[str] = None
     followups_json: Optional[str] = None
+    # 디버그 정보 — Vector/Graph raw 결과 + LLM 컨텍스트 (검색 과정 확인 패널용)
+    retrieval_json: Optional[str] = None
     is_error: bool = False
     created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,7 +4,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from .config import CORS_ORIGINS
 from .db.database import init_db
-from .routers import chat, history, meta, crawl
+from .routers import chat, history, meta, crawl, stats
 
 
 app = FastAPI(title="Lucid RAG Backend", version="0.1.0")
@@ -21,6 +21,7 @@ app.include_router(chat.router)
 app.include_router(history.router)
 app.include_router(meta.router)
 app.include_router(crawl.router)
+app.include_router(stats.router)
 
 
 @app.on_event("startup")

--- a/backend/app/routers/chat.py
+++ b/backend/app/routers/chat.py
@@ -48,19 +48,23 @@ async def chat(req: ChatRequest):
             answer = result["answer"]
             sources = result["sources"]
             knowledge_graph = result.get("knowledge_graph")
+            retrieval = result.get("retrieval")
 
             with DBSession(engine) as db2:
                 session_svc.add_message(
                     db2, session_id, role="assistant",
                     content=answer, sources=sources, graph_data=knowledge_graph,
+                    retrieval=retrieval,
                 )
 
             # text 를 먼저 보내 프론트가 assistant 버블을 생성하게 한 뒤
-            # sources/graph 로 메시지 메타를 보강. (프론트 routeChunk 가 첫 'text'에서만 버블 생성)
+            # sources/graph/retrieval 로 메시지 메타를 보강. (프론트 routeChunk 가 첫 'text'에서만 버블 생성)
             yield _sse({"type": "text", "content": answer})
             yield _sse({"type": "sources", "sources": sources})
             if knowledge_graph is not None:
                 yield _sse({"type": "graph", "graphData": knowledge_graph})
+            if retrieval is not None:
+                yield _sse({"type": "retrieval", "retrieval": retrieval})
             yield _sse({"type": "done"})
         except Exception as e:
             err = f"{type(e).__name__}: {e}"

--- a/backend/app/routers/stats.py
+++ b/backend/app/routers/stats.py
@@ -1,0 +1,119 @@
+"""GET /api/stats — 데이터 수집 모니터링용 통계.
+
+notices.json 을 집계해서 대시보드에 필요한 수치를 반환.
+별도 DB 없이 raw 파일만 읽는다 (가벼움 + 매번 최신값).
+"""
+import os
+import json
+from collections import defaultdict
+from datetime import datetime, timedelta
+
+from fastapi import APIRouter
+
+from ..config import NOTICES_JSON_PATH
+from ..services import crawler
+
+
+router = APIRouter(prefix="/api", tags=["stats"])
+
+
+# 키워드 기반 카테고리 매핑 (notices.json 에 category 필드가 없어서 제목으로 추정)
+CATEGORY_KEYWORDS: list[tuple[str, list[str]]] = [
+    ("장학",   ["장학", "학자금", "근로장학"]),
+    ("학사",   ["수강", "졸업", "성적", "학적", "전과", "복수전공", "부전공", "학위"]),
+    ("취업",   ["취업", "채용", "기업", "인턴", "공채", "면접"]),
+    ("행사",   ["행사", "공모", "대회", "경진", "세미나", "특강", "박람회"]),
+    ("기숙사", ["기숙사", "생활관", "BTL"]),
+    ("국제",   ["해외", "교환", "글로벌", "international"]),
+]
+
+
+def _categorize(title: str) -> str:
+    if not title:
+        return "기타"
+    t = title.lower()
+    for cat, kws in CATEGORY_KEYWORDS:
+        if any(kw.lower() in t for kw in kws):
+            return cat
+    return "기타"
+
+
+@router.get("/stats")
+def stats():
+    if not os.path.exists(NOTICES_JSON_PATH):
+        return {
+            "totalNotices": 0,
+            "totalAttachments": 0,
+            "categoryDistribution": [],
+            "timeline": [],
+            "latestNotices": [],
+            "lastCrawledAt": "",
+            "syncStatus": crawler.status(),
+        }
+
+    with open(NOTICES_JSON_PATH, encoding="utf-8") as f:
+        notices = json.load(f)
+
+    total_att = sum(len(n.get("attachments", []) or []) for n in notices)
+
+    # 카테고리 분포
+    cat_count: dict[str, int] = defaultdict(int)
+    for n in notices:
+        cat_count[_categorize(n.get("title", ""))] += 1
+    category_distribution = [
+        {"category": k, "count": v}
+        for k, v in sorted(cat_count.items(), key=lambda kv: kv[1], reverse=True)
+    ]
+
+    # 타임라인 (최근 30일 일자별)
+    date_count: dict[str, int] = defaultdict(int)
+    for n in notices:
+        d = (n.get("date") or "").strip()
+        if d:
+            date_count[d] += 1
+    today = datetime.utcnow().date()
+    timeline = []
+    for i in range(29, -1, -1):
+        d = (today - timedelta(days=i)).isoformat()
+        timeline.append({"date": d, "count": date_count.get(d, 0)})
+
+    # 최신 공지 10건 (date 기준 내림차순)
+    sorted_notices = sorted(
+        notices,
+        key=lambda n: (n.get("date") or ""),
+        reverse=True,
+    )
+    latest = [
+        {
+            "num": n.get("num", ""),
+            "title": n.get("title", ""),
+            "date": n.get("date", ""),
+            "url": n.get("url", ""),
+            "category": _categorize(n.get("title", "")),
+            "attachmentCount": len(n.get("attachments", []) or []),
+        }
+        for n in sorted_notices[:10]
+    ]
+
+    last_crawled_at = ""
+    try:
+        mtime = os.path.getmtime(NOTICES_JSON_PATH)
+        last_crawled_at = datetime.fromtimestamp(mtime).isoformat()
+    except Exception:
+        pass
+
+    return {
+        "totalNotices": len(notices),
+        "totalAttachments": total_att,
+        "categoryDistribution": category_distribution,
+        "timeline": timeline,
+        "latestNotices": latest,
+        "lastCrawledAt": last_crawled_at,
+        "syncStatus": crawler.status(),
+    }
+
+
+@router.get("/crawl/logs")
+def crawl_logs():
+    """최근 크롤/파이프라인 로그 (ring buffer)."""
+    return {"logs": crawler.recent_logs()}

--- a/backend/app/services/crawler.py
+++ b/backend/app/services/crawler.py
@@ -2,7 +2,7 @@
 
 The public API is still named "crawl" for frontend compatibility, but the
 operation now reflects new data into search: crawl, download attachments, parse,
-rebuild Chroma, update Neo4j, then clear in-process RAG caches.
+incrementally update Chroma and Neo4j, then clear in-process RAG caches.
 """
 from __future__ import annotations
 
@@ -42,6 +42,27 @@ _state = {
     "finished_at": None,
 }
 
+# 최근 동기화 로그 ring buffer — 대시보드에서 폴링해서 보여줌
+_LOG_BUFFER_MAX = 200
+_log_buffer: list[dict] = []
+
+
+def _append_log(level: str, step: SyncStep, message: str) -> None:
+    with _lock:
+        _log_buffer.append({
+            "ts": _now(),
+            "level": level,
+            "step": step,
+            "message": message,
+        })
+        if len(_log_buffer) > _LOG_BUFFER_MAX:
+            del _log_buffer[: len(_log_buffer) - _LOG_BUFFER_MAX]
+
+
+def recent_logs() -> list[dict]:
+    with _lock:
+        return list(_log_buffer)
+
 
 @lru_cache(maxsize=1)
 def _load_crawler_module():
@@ -64,6 +85,9 @@ def _set_state(
     started_at: str | None = None,
     finished_at: str | None = None,
 ) -> None:
+    log_step: SyncStep | None = None
+    log_message: str | None = None
+    log_level = "info"
     with _lock:
         if running is not None:
             _state["running"] = running
@@ -77,6 +101,14 @@ def _set_state(
             _state["started_at"] = started_at
         if finished_at is not None:
             _state["finished_at"] = finished_at
+        # 단계/메시지 변화 시 로그 1줄 (락 안에서 채우고 밖에서 append — re-entrancy 방지)
+        if step is not None or message is not None:
+            log_step = _state["step"]
+            log_message = _state["message"]
+            if step == "error" or last_error:
+                log_level = "error"
+    if log_step is not None:
+        _append_log(log_level, log_step, log_message or "")
 
 
 def _run_pipeline_script(
@@ -152,8 +184,8 @@ def run_full_sync(max_pages: int = 3) -> None:
         module.download_attachments(notices)
 
         _run_pipeline_script("01_parser.py", "parse", "문서와 첨부파일을 파싱하는 중")
-        _run_pipeline_script("02_vector_db.py", "vector", "Vector DB를 재빌드하는 중")
-        _run_pipeline_script("03_graph_db.py", "graph", "Graph DB를 재빌드하는 중", "--rebuild")
+        _run_pipeline_script("02_vector_db.py", "vector", "Vector DB를 증분 갱신하는 중")
+        _run_pipeline_script("03_graph_db.py", "graph", "Graph DB를 증분 갱신하는 중")
         _clear_rag_caches()
 
         _set_state(

--- a/backend/app/services/rag.py
+++ b/backend/app/services/rag.py
@@ -136,8 +136,36 @@ def run_hybrid_rag(query: str) -> dict[str, Any]:
         query=query,
     )
 
+    # 검색 과정 디버그용 — Vector 결과 + Graph relations + LLM 컨텍스트
+    vector_items = [
+        {
+            "chunkId": d.get("chunk_id", "") or "",
+            "source": d.get("source", "") or "",
+            "score": d.get("score"),
+            "preview": (d.get("content", "") or "")[:300],
+        }
+        for d in raw_docs
+    ]
+    graph_items = [
+        {
+            "from": (rel.get("from") or "").strip(),
+            "relation": (rel.get("relation") or "").strip(),
+            "to": (rel.get("to") or "").strip(),
+        }
+        for rel in (result.get("graph_relations") or [])
+        if rel.get("from") and rel.get("to")
+    ]
+    context = result.get("context") or ""
+    retrieval = {
+        "vector": vector_items,
+        "graph": graph_items,
+        "context": context[:8000],   # 너무 길면 잘라서 송신 (디버그용)
+        "contextLength": len(context),
+    }
+
     return {
         "answer": result.get("answer", "") or "",
         "sources": sources,
         "knowledge_graph": knowledge_graph,  # None 가능
+        "retrieval": retrieval,
     }

--- a/backend/app/services/session.py
+++ b/backend/app/services/session.py
@@ -35,6 +35,7 @@ def add_message(
     sources: Optional[list[dict]] = None,
     graph_data: Optional[dict] = None,
     followups: Optional[list[str]] = None,
+    retrieval: Optional[dict] = None,
     is_error: bool = False,
 ) -> Message:
     msg = Message(
@@ -45,6 +46,7 @@ def add_message(
         sources_json=json.dumps(sources, ensure_ascii=False) if sources else None,
         graph_json=json.dumps(graph_data, ensure_ascii=False) if graph_data else None,
         followups_json=json.dumps(followups, ensure_ascii=False) if followups else None,
+        retrieval_json=json.dumps(retrieval, ensure_ascii=False) if retrieval else None,
         is_error=is_error,
     )
     db.add(msg)
@@ -91,6 +93,7 @@ def get_session_messages(db: DBSession, session_id: str) -> Optional[list[dict]]
             "sources": json.loads(m.sources_json) if m.sources_json else None,
             "graphData": json.loads(m.graph_json) if m.graph_json else None,
             "followups": json.loads(m.followups_json) if m.followups_json else None,
+            "retrieval": json.loads(m.retrieval_json) if m.retrieval_json else None,
             "createdAt": m.created_at.isoformat(),
             "isError": m.is_error,
         }

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -5,19 +5,24 @@
 import { useState } from 'react';
 import { ChatPage } from '@/pages/chat';
 import { SettingsPage } from '@/pages/settings/SettingsPage';
+import { DashboardPage } from '@/pages/admin';
 import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 
-type View = 'chat' | 'settings';
+type View = 'chat' | 'settings' | 'admin';
 
 export function App() {
   const [view, setView] = useState<View>('chat');
+  const goChat = () => setView('chat');
   return (
     <ErrorBoundary>
-      {view === 'chat' ? (
-        <ChatPage onOpenSettings={() => setView('settings')} />
-      ) : (
-        <SettingsPage onClose={() => setView('chat')} />
+      {view === 'chat' && (
+        <ChatPage
+          onOpenSettings={() => setView('settings')}
+          onOpenAdmin={() => setView('admin')}
+        />
       )}
+      {view === 'settings' && <SettingsPage onClose={goChat} />}
+      {view === 'admin' && <DashboardPage onClose={goChat} />}
     </ErrorBoundary>
   );
 }

--- a/front/src/api/stats.api.ts
+++ b/front/src/api/stats.api.ts
@@ -1,0 +1,16 @@
+// api/stats.api.ts
+// 데이터 수집 대시보드 — 통계 + 크롤 로그.
+
+import { http } from '@/lib/axios';
+import { ENDPOINTS } from '@/constants/api.constant';
+import type { StatsResponse, CrawlLogsResponse } from '@/types/stats.type';
+
+export async function fetchStats(): Promise<StatsResponse> {
+  const { data } = await http.get<StatsResponse>(ENDPOINTS.stats);
+  return data;
+}
+
+export async function fetchCrawlLogs(): Promise<CrawlLogsResponse> {
+  const { data } = await http.get<CrawlLogsResponse>(ENDPOINTS.crawlLogs);
+  return data;
+}

--- a/front/src/components/admin/CategoryBars.tsx
+++ b/front/src/components/admin/CategoryBars.tsx
@@ -1,0 +1,49 @@
+// components/admin/CategoryBars.tsx
+// 카테고리 분포 — 가로 막대 (외부 차트 라이브러리 없이 div 너비로 구현).
+
+import type { CategoryBucket } from '@/types/stats.type';
+
+interface Props {
+  buckets: CategoryBucket[];
+}
+
+const COLORS: Record<string, string> = {
+  '학사':   'bg-brand-500',
+  '장학':   'bg-amber-500',
+  '취업':   'bg-emerald-500',
+  '행사':   'bg-pink-500',
+  '기숙사': 'bg-violet-500',
+  '국제':   'bg-cyan-500',
+  '기타':   'bg-ink-3',
+};
+
+export function CategoryBars({ buckets }: Props) {
+  const max = Math.max(1, ...buckets.map((b) => b.count));
+  return (
+    <div className="flex flex-col gap-3 rounded-cd-lg border border-line bg-surface px-5 py-4">
+      <h3 className="text-[13px] font-semibold tracking-tight text-ink">카테고리 분포</h3>
+      {buckets.length === 0 ? (
+        <div className="py-6 text-center text-[12px] text-ink-3">데이터 없음</div>
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {buckets.map((b) => (
+            <div key={b.category} className="flex items-center gap-2.5">
+              <span className="w-14 flex-shrink-0 text-[12px] font-medium text-ink-2">
+                {b.category}
+              </span>
+              <div className="flex-1 overflow-hidden rounded-full bg-canvas">
+                <div
+                  className={`${COLORS[b.category] ?? 'bg-ink-3'} h-2 rounded-full transition-all`}
+                  style={{ width: `${(b.count / max) * 100}%` }}
+                />
+              </div>
+              <span className="w-8 flex-shrink-0 text-right text-[12px] font-semibold text-ink">
+                {b.count}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/front/src/components/admin/CrawlLogStream.tsx
+++ b/front/src/components/admin/CrawlLogStream.tsx
@@ -1,0 +1,89 @@
+// components/admin/CrawlLogStream.tsx
+// 실시간 크롤 로그 — 단계별 컬러 + 자동 스크롤.
+
+import { useEffect, useRef } from 'react';
+import type { CrawlLogEntry } from '@/types/stats.type';
+import { cn } from '@/utils/cn';
+
+interface Props {
+  logs: CrawlLogEntry[];
+  running: boolean;
+}
+
+const STEP_LABEL: Record<string, string> = {
+  idle: '대기',
+  crawl: '크롤',
+  download: '첨부',
+  parse: '파싱',
+  vector: '벡터',
+  graph: '그래프',
+  reload: '리로드',
+  done: '완료',
+  error: '오류',
+};
+
+const STEP_COLOR: Record<string, string> = {
+  idle: 'bg-ink-3',
+  crawl: 'bg-brand-500',
+  download: 'bg-amber-500',
+  parse: 'bg-violet-500',
+  vector: 'bg-emerald-500',
+  graph: 'bg-pink-500',
+  reload: 'bg-cyan-500',
+  done: 'bg-emerald-600',
+  error: 'bg-red-500',
+};
+
+export function CrawlLogStream({ logs, running }: Props) {
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (ref.current) {
+      ref.current.scrollTop = ref.current.scrollHeight;
+    }
+  }, [logs.length]);
+
+  return (
+    <div className="flex h-[320px] flex-col rounded-cd-lg border border-line bg-surface">
+      <div className="flex items-center justify-between border-b border-line-2 px-5 py-3">
+        <h3 className="text-[13px] font-semibold tracking-tight text-ink">실시간 동기화 로그</h3>
+        <div className="flex items-center gap-1.5 text-[11.5px] text-ink-3">
+          <span className={cn(
+            'block h-1.5 w-1.5 rounded-full',
+            running
+              ? 'bg-brand-500 shadow-[0_0_0_3px_rgba(37,99,235,0.18)] animate-pulse'
+              : 'bg-ink-4',
+          )} />
+          {running ? '진행 중' : '대기'}
+        </div>
+      </div>
+      <div ref={ref} className="flex-1 overflow-y-auto px-3 py-2 font-mono text-[11.5px]">
+        {logs.length === 0 ? (
+          <div className="py-12 text-center text-ink-3">
+            아직 로그가 없습니다. 설정에서 "지금 동기화" 를 누르면 단계별 로그가 표시됩니다.
+          </div>
+        ) : (
+          <div className="flex flex-col gap-1">
+            {logs.map((l, i) => (
+              <div key={i} className="flex items-start gap-2.5 px-2 py-1">
+                <span className="mt-[3px] text-ink-4">{l.ts.slice(11, 19)}</span>
+                <span className={cn(
+                  'rounded px-1.5 py-px text-[10px] font-semibold text-white',
+                  STEP_COLOR[l.step] ?? 'bg-ink-3',
+                )}>
+                  {STEP_LABEL[l.step] ?? l.step}
+                </span>
+                <span className={cn(
+                  'flex-1',
+                  l.level === 'error' ? 'text-red-600' : 'text-ink-2',
+                )}>
+                  {l.message}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/front/src/components/admin/LatestNoticesList.tsx
+++ b/front/src/components/admin/LatestNoticesList.tsx
@@ -1,0 +1,70 @@
+// components/admin/LatestNoticesList.tsx
+// 최근 수집된 공지 N건 — 누락 검증용.
+
+import { Icon } from '@/components/common/Icon';
+import type { LatestNotice } from '@/types/stats.type';
+
+interface Props {
+  notices: LatestNotice[];
+}
+
+const CAT_COLOR: Record<string, string> = {
+  '학사':   'bg-brand-50 text-brand-700',
+  '장학':   'bg-amber-50 text-amber-900',
+  '취업':   'bg-emerald-50 text-emerald-800',
+  '행사':   'bg-pink-50 text-pink-800',
+  '기숙사': 'bg-violet-50 text-violet-800',
+  '국제':   'bg-cyan-50 text-cyan-800',
+  '기타':   'bg-canvas text-ink-3',
+};
+
+export function LatestNoticesList({ notices }: Props) {
+  return (
+    <div className="flex flex-col rounded-cd-lg border border-line bg-surface">
+      <div className="border-b border-line-2 px-5 py-3">
+        <h3 className="text-[13px] font-semibold tracking-tight text-ink">
+          최근 수집 공지 ({notices.length}건)
+        </h3>
+      </div>
+      {notices.length === 0 ? (
+        <div className="py-10 text-center text-[12px] text-ink-3">데이터 없음</div>
+      ) : (
+        <ul className="flex flex-col">
+          {notices.map((n) => (
+            <li key={n.num} className="border-b border-line-2 px-5 py-3 last:border-b-0">
+              <div className="flex items-start gap-3">
+                <span className={
+                  `flex-shrink-0 rounded-full px-2 py-[3px] text-[10.5px] font-semibold ${
+                    CAT_COLOR[n.category] ?? CAT_COLOR['기타']
+                  }`
+                }>
+                  {n.category}
+                </span>
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
+                  <a href={n.url} target="_blank" rel="noopener noreferrer"
+                     className="line-clamp-1 text-[13.5px] font-medium text-ink no-underline
+                                hover:text-brand-600">
+                    {n.title}
+                  </a>
+                  <div className="flex items-center gap-3 text-[11.5px] text-ink-3">
+                    <span>{n.date}</span>
+                    <span className="text-ink-4">·</span>
+                    <span>#{n.num}</span>
+                    {n.attachmentCount > 0 && (
+                      <>
+                        <span className="text-ink-4">·</span>
+                        <span className="flex items-center gap-1">
+                          <Icon.Doc /> 첨부 {n.attachmentCount}개
+                        </span>
+                      </>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/front/src/components/admin/StatCard.tsx
+++ b/front/src/components/admin/StatCard.tsx
@@ -1,0 +1,25 @@
+// components/admin/StatCard.tsx
+// 큰 숫자 1개 + 라벨 + 보조 텍스트 — KPI 카드.
+
+import type { ReactNode } from 'react';
+
+interface Props {
+  label: string;
+  value: number | string;
+  sub?: string;
+  icon?: ReactNode;
+}
+
+export function StatCard({ label, value, sub, icon }: Props) {
+  return (
+    <div className="flex flex-col gap-1.5 rounded-cd-lg border border-line bg-surface px-5 py-4">
+      <div className="flex items-center gap-2 text-[11.5px] font-semibold uppercase tracking-wider
+                      text-ink-3">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <div className="text-[28px] font-bold leading-none tracking-tight text-ink">{value}</div>
+      {sub && <div className="text-[12px] text-ink-3">{sub}</div>}
+    </div>
+  );
+}

--- a/front/src/components/admin/TimelineSparkline.tsx
+++ b/front/src/components/admin/TimelineSparkline.tsx
@@ -1,0 +1,93 @@
+// components/admin/TimelineSparkline.tsx
+// 최근 30일 일자별 공지 수 — SVG sparkline (외부 차트 없이).
+
+import type { TimelinePoint } from '@/types/stats.type';
+
+interface Props {
+  points: TimelinePoint[];
+}
+
+const W = 720;
+const H = 110;
+const PAD = { l: 30, r: 12, t: 8, b: 22 };
+
+export function TimelineSparkline({ points }: Props) {
+  if (points.length === 0) {
+    return (
+      <div className="rounded-cd-lg border border-line bg-surface px-5 py-4">
+        <h3 className="mb-2 text-[13px] font-semibold tracking-tight text-ink">
+          최근 30일 수집 추이
+        </h3>
+        <div className="py-8 text-center text-[12px] text-ink-3">데이터 없음</div>
+      </div>
+    );
+  }
+
+  const max = Math.max(1, ...points.map((p) => p.count));
+  const innerW = W - PAD.l - PAD.r;
+  const innerH = H - PAD.t - PAD.b;
+  const dx = innerW / Math.max(1, points.length - 1);
+  const xy = (i: number, v: number) => [
+    PAD.l + i * dx,
+    PAD.t + innerH - (v / max) * innerH,
+  ] as const;
+
+  // 영역(area) 패스 + 선(line) 패스
+  const linePath = points
+    .map((p, i) => {
+      const [x, y] = xy(i, p.count);
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+  const areaPath = `${linePath} L${(PAD.l + (points.length - 1) * dx).toFixed(1)},${PAD.t + innerH} L${PAD.l},${PAD.t + innerH} Z`;
+
+  // x축 라벨 — 처음/중간/끝 3개만
+  const labelIdx = [0, Math.floor(points.length / 2), points.length - 1];
+
+  const total = points.reduce((s, p) => s + p.count, 0);
+
+  return (
+    <div className="rounded-cd-lg border border-line bg-surface px-5 py-4">
+      <div className="mb-2 flex items-baseline justify-between">
+        <h3 className="text-[13px] font-semibold tracking-tight text-ink">
+          최근 30일 수집 추이
+        </h3>
+        <span className="text-[11.5px] text-ink-3">총 {total}건</span>
+      </div>
+      <svg viewBox={`0 0 ${W} ${H}`} className="w-full" preserveAspectRatio="none">
+        {/* y 가이드선 */}
+        <line x1={PAD.l} x2={W - PAD.r} y1={PAD.t} y2={PAD.t}
+              stroke="currentColor" strokeWidth={0.5} className="text-line" />
+        <line x1={PAD.l} x2={W - PAD.r} y1={PAD.t + innerH} y2={PAD.t + innerH}
+              stroke="currentColor" strokeWidth={0.5} className="text-line" />
+        {/* y 축 라벨 */}
+        <text x={PAD.l - 6} y={PAD.t + 4} textAnchor="end" fontSize={10} className="fill-ink-3">
+          {max}
+        </text>
+        <text x={PAD.l - 6} y={PAD.t + innerH + 3} textAnchor="end" fontSize={10}
+              className="fill-ink-3">0</text>
+        {/* area */}
+        <path d={areaPath} className="fill-brand-500/15" />
+        {/* line */}
+        <path d={linePath} fill="none" strokeWidth={1.6}
+              className="stroke-brand-500" strokeLinecap="round" strokeLinejoin="round" />
+        {/* 데이터 점 (count > 0 인 곳만) */}
+        {points.map((p, i) => {
+          if (p.count === 0) return null;
+          const [x, y] = xy(i, p.count);
+          return <circle key={i} cx={x} cy={y} r={2.2} className="fill-brand-500" />;
+        })}
+        {/* x축 라벨 */}
+        {labelIdx.map((i) => {
+          const [x] = xy(i, 0);
+          return (
+            <text key={i} x={x} y={H - 6} textAnchor="middle"
+                  fontSize={10} className="fill-ink-3">
+              {points[i].date.slice(5)}
+            </text>
+          );
+        })}
+      </svg>
+    </div>
+  );
+}

--- a/front/src/components/chat/MessageBubble.tsx
+++ b/front/src/components/chat/MessageBubble.tsx
@@ -8,6 +8,7 @@ import { IconButton } from '@/components/common/IconButton';
 import { RAGPipeline } from './RAGPipeline';
 import { AnnouncementCard } from './AnnouncementCard';
 import { MiniGraph } from './MiniGraph';
+import { RetrievalDebugPanel } from './RetrievalDebugPanel';
 import { Markdown } from '@/utils/parseMarkdown';
 import { cn } from '@/utils/cn';
 import { useSidebarStore } from '@/store/sidebarStore';
@@ -31,6 +32,7 @@ export function MessageBubble({
   showMiniGraph,
 }: Props) {
   const [copied, setCopied] = useState(false);
+  const [showRetrieval, setShowRetrieval] = useState(false);
   // 보관함 상태는 sidebarStore가 단일 출처. msg.isBookmarked 플래그는 무시.
   const isBookmarked = useSidebarStore((s) => s.bookmarks.some((b) => b.messageId === msg.id));
   const handleCopy = () => {
@@ -125,6 +127,29 @@ export function MessageBubble({
                 graphKey={msg.graphKey ?? 'general'}
                 onExpand={() => onExpandGraph(msg)}
               />
+            )}
+
+            {!msg.streaming && msg.retrieval && (
+              <div className="mt-2">
+                <button
+                  type="button"
+                  onClick={() => setShowRetrieval((s) => !s)}
+                  className="flex items-center gap-1.5 rounded-md border-0 bg-transparent
+                             px-2 py-1 text-[11.5px] font-medium text-ink-3
+                             cursor-pointer transition-colors hover:bg-canvas hover:text-ink-2"
+                  aria-expanded={showRetrieval}
+                >
+                  <Icon.Search />
+                  {showRetrieval ? '검색 과정 접기' : '검색 과정 보기'}
+                  <span className="text-ink-4">
+                    · Vector {msg.retrieval.vector.length} · Graph {msg.retrieval.graph.length}
+                    {msg.retrieval.contextLength > 0
+                      ? ` · 컨텍스트 ${msg.retrieval.contextLength.toLocaleString()}자`
+                      : ''}
+                  </span>
+                </button>
+                {showRetrieval && <RetrievalDebugPanel data={msg.retrieval} />}
+              </div>
             )}
 
             {!msg.streaming && msg.followups && msg.followups.length > 0 && (

--- a/front/src/components/chat/RetrievalDebugPanel.tsx
+++ b/front/src/components/chat/RetrievalDebugPanel.tsx
@@ -1,0 +1,151 @@
+// components/chat/RetrievalDebugPanel.tsx
+// 검색 과정 확인 패널 — Vector / Graph / LLM 컨텍스트 3탭.
+// 답변 메시지 하단 토글로 펼치는 인라인 패널 (별도 라우팅 X).
+
+import { useState } from 'react';
+import { Icon } from '@/components/common/Icon';
+import type { RetrievalDebug } from '@/types/retrieval.type';
+import { cn } from '@/utils/cn';
+
+interface Props {
+  data: RetrievalDebug;
+}
+
+type Tab = 'vector' | 'graph' | 'context';
+
+export function RetrievalDebugPanel({ data }: Props) {
+  const [tab, setTab] = useState<Tab>('vector');
+
+  const counts: Record<Tab, number> = {
+    vector: data.vector.length,
+    graph: data.graph.length,
+    context: data.contextLength,
+  };
+
+  return (
+    <div className="mt-2 overflow-hidden rounded-cd-md border border-line bg-surface-2">
+      {/* 탭 헤더 */}
+      <div className="flex items-center justify-between border-b border-line-2 px-3 py-2">
+        <div className="flex items-center gap-1">
+          {(['vector', 'graph', 'context'] as const).map((t) => (
+            <button
+              key={t}
+              type="button"
+              onClick={() => setTab(t)}
+              className={cn(
+                'flex items-center gap-1 rounded-md border-0 px-2.5 py-1 text-[11.5px] font-medium',
+                'cursor-pointer transition-colors',
+                tab === t
+                  ? 'bg-brand-50 text-brand-700'
+                  : 'bg-transparent text-ink-3 hover:bg-canvas',
+              )}
+            >
+              <span>{TAB_LABEL[t]}</span>
+              <span className={cn(
+                'rounded-full px-1.5 text-[10px]',
+                tab === t ? 'bg-brand-100 text-brand-700' : 'bg-line text-ink-3',
+              )}>
+                {t === 'context' ? `${counts[t]}자` : counts[t]}
+              </span>
+            </button>
+          ))}
+        </div>
+        <span className="flex items-center gap-1 text-[10.5px] text-ink-4">
+          <Icon.Sparkle /> 답변 근거 투명 공개
+        </span>
+      </div>
+
+      {/* 탭 본문 */}
+      <div className="max-h-[360px] overflow-y-auto px-3 py-3">
+        {tab === 'vector' && <VectorTab items={data.vector} />}
+        {tab === 'graph' && <GraphTab items={data.graph} />}
+        {tab === 'context' && <ContextTab content={data.context} total={data.contextLength} />}
+      </div>
+    </div>
+  );
+}
+
+const TAB_LABEL: Record<Tab, string> = {
+  vector: 'Vector 결과',
+  graph: 'Graph 결과',
+  context: 'LLM 컨텍스트',
+};
+
+function VectorTab({ items }: { items: RetrievalDebug['vector'] }) {
+  if (items.length === 0) {
+    return <div className="py-6 text-center text-[12px] text-ink-3">Vector 검색 결과 없음</div>;
+  }
+  return (
+    <ul className="flex flex-col gap-2">
+      {items.map((v, i) => (
+        <li key={v.chunkId || i}
+            className="flex flex-col gap-1 rounded-cd-md border border-line bg-surface px-3 py-2.5">
+          <div className="flex items-center justify-between gap-2">
+            <span className="line-clamp-1 text-[12px] font-medium text-ink-2">
+              <span className="mr-1.5 text-brand-500">[{i + 1}]</span>
+              {v.source || '(출처 미상)'}
+            </span>
+            {typeof v.score === 'number' && (
+              <span className="flex-shrink-0 rounded-full bg-brand-50 px-2 py-[2px]
+                               text-[10.5px] font-semibold text-brand-700">
+                score {v.score.toFixed(3)}
+              </span>
+            )}
+          </div>
+          <p className="line-clamp-3 whitespace-pre-wrap text-[11.5px] leading-snug text-ink-3">
+            {v.preview || '(빈 본문)'}
+          </p>
+          {v.chunkId && (
+            <span className="font-mono text-[10px] text-ink-4">{v.chunkId}</span>
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function GraphTab({ items }: { items: RetrievalDebug['graph'] }) {
+  if (items.length === 0) {
+    return <div className="py-6 text-center text-[12px] text-ink-3">Graph 관계 없음</div>;
+  }
+  return (
+    <ul className="flex flex-col gap-1.5">
+      {items.map((g, i) => (
+        <li key={i} className="flex items-center gap-2 rounded-cd-md border border-line
+                                bg-surface px-3 py-2 text-[12px]">
+          <span className="font-medium text-ink-2">{g.from}</span>
+          <span className="flex items-center gap-1 text-ink-4">
+            <span>—[</span>
+            <span className="rounded bg-brand-50 px-1.5 py-px text-[10.5px] font-semibold
+                             text-brand-700">{g.relation || '관계'}</span>
+            <span>]→</span>
+          </span>
+          <span className="font-medium text-ink-2">{g.to}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function ContextTab({ content, total }: { content: string; total: number }) {
+  if (!content) {
+    return <div className="py-6 text-center text-[12px] text-ink-3">컨텍스트 없음</div>;
+  }
+  const truncated = total > content.length;
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between text-[10.5px] text-ink-4">
+        <span>LLM 에 전달된 raw 컨텍스트</span>
+        <span>
+          {content.length.toLocaleString()}자
+          {truncated && ` / 원본 ${total.toLocaleString()}자 (앞부분만 표시)`}
+        </span>
+      </div>
+      <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-cd-md
+                      border border-line bg-surface p-3 font-mono text-[11px]
+                      leading-relaxed text-ink-2">
+        {content}
+      </pre>
+    </div>
+  );
+}

--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -12,9 +12,11 @@ import { formatSyncTime } from '@/utils/formatDate';
 
 interface Props {
   onOpenGraph: () => void;
+  onOpenAdmin?: () => void;
+  onOpenSettings?: () => void;
 }
 
-export function Header({ onOpenGraph }: Props) {
+export function Header({ onOpenGraph, onOpenAdmin, onOpenSettings }: Props) {
   const toggleSidebar = useSidebarStore((s) => s.toggleSidebar);
   const hasMessages = useChatStore((s) => s.messages.length > 0);
   const { meta } = useAnnouncements();
@@ -49,6 +51,16 @@ export function Header({ onOpenGraph }: Props) {
           <Button variant="pill" leadingIcon={<Icon.Graph />} onClick={onOpenGraph}>
             지식 그래프
           </Button>
+        )}
+        {onOpenAdmin && (
+          <IconButton aria-label="데이터 수집 모니터링" onClick={onOpenAdmin}>
+            <Icon.Refresh />
+          </IconButton>
+        )}
+        {onOpenSettings && (
+          <IconButton aria-label="설정" onClick={onOpenSettings}>
+            <Icon.Settings />
+          </IconButton>
         )}
         <Button variant="pill" leadingIcon={<Icon.Share />}>공유</Button>
       </div>

--- a/front/src/constants/api.constant.ts
+++ b/front/src/constants/api.constant.ts
@@ -23,6 +23,10 @@ export const ENDPOINTS = {
   crawl:       '/api/crawl',
   /** GET — 크롤러 진행 상태 */
   crawlStatus: '/api/crawl/status',
+  /** GET — 대시보드 통계 */
+  stats:       '/api/stats',
+  /** GET — 최근 크롤 로그 (ring buffer) */
+  crawlLogs:   '/api/crawl/logs',
 } as const;
 
 /** VITE_USE_MOCK=true 로 명시해야만 mock 모드 활성화 */

--- a/front/src/hooks/useChat.ts
+++ b/front/src/hooks/useChat.ts
@@ -122,6 +122,9 @@ export function useChat() {
               graphData: chunk.graphData,
             });
             return;
+          case 'retrieval':
+            updateMessage(assistantId, { retrieval: chunk.retrieval });
+            return;
           case 'session':
             if (chunk.sessionId) setSessionId(chunk.sessionId);
             return;

--- a/front/src/hooks/useStats.ts
+++ b/front/src/hooks/useStats.ts
@@ -1,0 +1,41 @@
+// hooks/useStats.ts
+// 대시보드 데이터 — 통계 + 크롤 로그를 일정 주기로 폴링.
+
+import { useEffect, useState } from 'react';
+import { fetchStats, fetchCrawlLogs } from '@/api/stats.api';
+import type { StatsResponse, CrawlLogEntry } from '@/types/stats.type';
+
+const STATS_INTERVAL_MS = 30_000;   // 30초 — 통계는 자주 안 바뀜
+const LOG_INTERVAL_MS   = 3_000;    // 3초  — 크롤 진행 중일 때 부드러운 갱신
+
+export function useStats() {
+  const [stats, setStats] = useState<StatsResponse | null>(null);
+  const [logs, setLogs] = useState<CrawlLogEntry[]>([]);
+  const [error, setError] = useState<Error | null>(null);
+
+  // stats — 30초 주기
+  useEffect(() => {
+    let alive = true;
+    const load = () =>
+      fetchStats()
+        .then((s) => { if (alive) setStats(s); })
+        .catch((e: Error) => { if (alive) setError(e); });
+    load();
+    const id = setInterval(load, STATS_INTERVAL_MS);
+    return () => { alive = false; clearInterval(id); };
+  }, []);
+
+  // logs — 3초 주기 (running 일 때만 빠르게, 평소엔 일찍 끊기)
+  useEffect(() => {
+    let alive = true;
+    const load = () =>
+      fetchCrawlLogs()
+        .then((r) => { if (alive) setLogs(r.logs); })
+        .catch(() => { /* ignore */ });
+    load();
+    const id = setInterval(load, LOG_INTERVAL_MS);
+    return () => { alive = false; clearInterval(id); };
+  }, []);
+
+  return { stats, logs, error };
+}

--- a/front/src/pages/admin/DashboardPage.tsx
+++ b/front/src/pages/admin/DashboardPage.tsx
@@ -1,0 +1,122 @@
+﻿// pages/admin/DashboardPage.tsx
+// 데이터 수집 모니터링 대시보드 — 관리자 검증용.
+
+import { IconButton } from '@/components/common/IconButton';
+import { Icon } from '@/components/common/Icon';
+import { CDLogo } from '@/components/common/CDLogo';
+import { StatCard } from '@/components/admin/StatCard';
+import { CategoryBars } from '@/components/admin/CategoryBars';
+import { TimelineSparkline } from '@/components/admin/TimelineSparkline';
+import { CrawlLogStream } from '@/components/admin/CrawlLogStream';
+import { LatestNoticesList } from '@/components/admin/LatestNoticesList';
+import { useStats } from '@/hooks/useStats';
+import { formatSyncTime } from '@/utils/formatDate';
+
+interface Props {
+  onClose: () => void;
+}
+
+const STEP_LABEL: Record<string, string> = {
+  idle: '대기 중',
+  crawl: '공지 목록 크롤링',
+  download: '첨부파일 다운로드',
+  parse: '문서 파싱',
+  vector: 'Vector DB 증분 갱신',
+  graph: 'Graph DB 증분 갱신',
+  reload: '검색 캐시 갱신',
+  done: '동기화 완료',
+  error: '동기화 실패',
+};
+
+export function DashboardPage({ onClose }: Props) {
+  const { stats, logs } = useStats();
+
+  const totalNotices       = stats?.totalNotices ?? 0;
+  const totalAttachments   = stats?.totalAttachments ?? 0;
+  const lastCrawledAt      = stats?.lastCrawledAt ?? '';
+  const sync               = stats?.syncStatus;
+  const stepLabel          = sync ? STEP_LABEL[sync.step] ?? sync.step : '—';
+  const running            = sync?.running ?? false;
+
+  return (
+    <div className="flex h-screen flex-col bg-canvas font-sans text-ink">
+      {/* 상단 바 */}
+      <div className="flex flex-shrink-0 items-center justify-between border-b border-line
+                      bg-white/70 px-6 py-3.5 backdrop-blur-md">
+        <div className="flex items-center gap-3">
+          <IconButton aria-label="뒤로가기" onClick={onClose}>
+            <Icon.ArrowLeft />
+          </IconButton>
+          <CDLogo size="sm" />
+          <h1 className="m-0 text-[18px] font-semibold tracking-tight">데이터 수집 모니터링</h1>
+        </div>
+        {sync && (
+          <div className="flex items-center gap-2 text-[12px]">
+            <span className={
+              `block h-1.5 w-1.5 rounded-full ${
+                running
+                  ? 'bg-brand-500 shadow-[0_0_0_3px_rgba(37,99,235,0.18)] animate-pulse'
+                  : sync.step === 'error'
+                  ? 'bg-red-500'
+                  : 'bg-emerald-500 shadow-[0_0_0_3px_rgba(16,185,129,0.15)]'
+              }`
+            } />
+            <span className="text-ink-2">{stepLabel}</span>
+            {sync.message && (
+              <span className="ml-1 text-ink-3">· {sync.message}</span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* 본문 */}
+      <div className="flex-1 overflow-y-auto px-8 pb-12 pt-6">
+        <div className="mx-auto flex max-w-[1100px] flex-col gap-5">
+          {/* KPI 4장 */}
+          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+            <StatCard
+              label="총 공지"
+              value={totalNotices.toLocaleString()}
+              sub={lastCrawledAt ? `마지막 동기화 ${formatSyncTime(lastCrawledAt)}` : '미수집'}
+              icon={<Icon.Doc />}
+            />
+            <StatCard
+              label="총 첨부파일"
+              value={totalAttachments.toLocaleString()}
+              sub={
+                totalNotices
+                  ? `공지당 평균 ${(totalAttachments / totalNotices).toFixed(1)}건`
+                  : '—'
+              }
+              icon={<Icon.Doc />}
+            />
+            <StatCard
+              label="현재 단계"
+              value={stepLabel}
+              sub={sync?.message ?? ''}
+              icon={<Icon.Refresh />}
+            />
+            <StatCard
+              label="카테고리"
+              value={stats?.categoryDistribution.length ?? 0}
+              sub="자동 분류"
+              icon={<Icon.Sparkle />}
+            />
+          </div>
+
+          {/* 추이 + 카테고리 */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-[2fr_1fr]">
+            <TimelineSparkline points={stats?.timeline ?? []} />
+            <CategoryBars buckets={stats?.categoryDistribution ?? []} />
+          </div>
+
+          {/* 로그 + 최근 공지 */}
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_1fr]">
+            <CrawlLogStream logs={logs} running={running} />
+            <LatestNoticesList notices={stats?.latestNotices ?? []} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/front/src/pages/admin/index.ts
+++ b/front/src/pages/admin/index.ts
@@ -1,0 +1,1 @@
+export { DashboardPage } from './DashboardPage';

--- a/front/src/pages/chat/ChatPage.tsx
+++ b/front/src/pages/chat/ChatPage.tsx
@@ -19,9 +19,10 @@ import type { KnowledgeGraph } from '@/types/graph.type';
 
 interface Props {
   onOpenSettings: () => void;
+  onOpenAdmin: () => void;
 }
 
-export function ChatPage({ onOpenSettings }: Props) {
+export function ChatPage({ onOpenSettings, onOpenAdmin }: Props) {
   const messages = useChatStore((s) => s.messages);
   const { send, abort, retryLast, isStreaming } = useChat();
   const { addBookmark, removeBookmark } = useSidebarStore();
@@ -74,7 +75,11 @@ export function ChatPage({ onOpenSettings }: Props) {
            }} />
       <Sidebar onOpenSettings={onOpenSettings} />
       <main className="relative z-[1] flex min-w-0 flex-1 flex-col">
-        <Header onOpenGraph={handleOpenTopicGraph} />
+        <Header
+          onOpenGraph={handleOpenTopicGraph}
+          onOpenAdmin={onOpenAdmin}
+          onOpenSettings={onOpenSettings}
+        />
         {isWelcome ? (
           <WelcomeScreen onPick={(q) => void send(q.title, q.id)} />
         ) : (

--- a/front/src/types/message.type.ts
+++ b/front/src/types/message.type.ts
@@ -3,6 +3,7 @@
 
 import type { AnnouncementSource } from './announcement.type';
 import type { KnowledgeGraph } from './graph.type';
+import type { RetrievalDebug } from './retrieval.type';
 
 export type MessageRole = 'user' | 'assistant';
 
@@ -17,6 +18,8 @@ export interface Message {
   graphKey?: string;
   /** 백엔드에서 동적으로 받은 그래프 데이터 (graphKey 보다 우선) */
   graphData?: KnowledgeGraph;
+  /** 검색 과정 디버그 — Vector/Graph raw + LLM 컨텍스트 */
+  retrieval?: RetrievalDebug;
   createdAt: string;
   isError?: boolean;
   isBookmarked?: boolean;
@@ -33,6 +36,7 @@ export type StreamChunkType =
   | 'sources'       // 출처 카드 페이로드
   | 'followups'     // 후속 질문 추천
   | 'graph'         // 지식 그래프 키
+  | 'retrieval'     // 검색 과정 디버그 (vector/graph/context)
   | 'session'       // 세션 ID 발급/확정
   | 'done'          // 스트림 종료
   | 'error';        // 에러
@@ -45,6 +49,8 @@ export interface StreamChunk {
   graphKey?: string;
   /** 백엔드에서 동적으로 보내는 그래프 데이터 */
   graphData?: KnowledgeGraph;
+  /** retrieval 청크의 검색 과정 디버그 데이터 */
+  retrieval?: RetrievalDebug;
   sessionId?: string;
   /** pipeline 청크일 때 단계 식별자 */
   step?: 'crawl' | 'retrieve' | 'rerank' | 'generate';

--- a/front/src/types/retrieval.type.ts
+++ b/front/src/types/retrieval.type.ts
@@ -1,0 +1,22 @@
+// types/retrieval.type.ts
+// 검색 과정 디버그 데이터 — 답변 근거(컨텍스트) 투명 공개용.
+
+export interface VectorResultItem {
+  chunkId: string;
+  source: string;
+  score: number | null;
+  preview: string;        // 본문 첫 ~300자
+}
+
+export interface GraphResultItem {
+  from: string;
+  relation: string;
+  to: string;
+}
+
+export interface RetrievalDebug {
+  vector: VectorResultItem[];
+  graph: GraphResultItem[];
+  context: string;          // LLM 에 전달된 raw 컨텍스트 (앞 8000자)
+  contextLength: number;    // 잘리기 전 원본 길이
+}

--- a/front/src/types/stats.type.ts
+++ b/front/src/types/stats.type.ts
@@ -1,0 +1,51 @@
+// types/stats.type.ts
+// 데이터 수집 모니터링 대시보드용 도메인 모델
+
+export interface CategoryBucket {
+  category: string;
+  count: number;
+}
+
+export interface TimelinePoint {
+  date: string;   // YYYY-MM-DD
+  count: number;
+}
+
+export interface LatestNotice {
+  num: string;
+  title: string;
+  date: string;
+  url: string;
+  category: string;
+  attachmentCount: number;
+}
+
+export interface SyncStatus {
+  running: boolean;
+  step: 'idle' | 'crawl' | 'download' | 'parse' | 'vector' | 'graph' | 'reload' | 'done' | 'error';
+  message: string;
+  lastError: string | null;
+  startedAt: string | null;
+  finishedAt: string | null;
+}
+
+export interface StatsResponse {
+  totalNotices: number;
+  totalAttachments: number;
+  categoryDistribution: CategoryBucket[];
+  timeline: TimelinePoint[];        // 최근 30일
+  latestNotices: LatestNotice[];     // 최신 10건
+  lastCrawledAt: string;
+  syncStatus: SyncStatus;
+}
+
+export interface CrawlLogEntry {
+  ts: string;                 // ISO datetime
+  level: 'info' | 'warn' | 'error';
+  step: SyncStatus['step'];
+  message: string;
+}
+
+export interface CrawlLogsResponse {
+  logs: CrawlLogEntry[];
+}


### PR DESCRIPTION
## 데이터 수집 모니터링 대시보드 (관리자 화면)
- 백엔드 `GET /api/stats` — 총 공지·첨부, 카테고리 분포(키워드 기반 자동 분류), 최근 30일 타임라인, 최신 공지 10건, sync 상태
- 백엔드 `GET /api/crawl/logs` — 동기화 단계별 로그 ring buffer (최대 200줄) crawler._set_state 훅에서 자동 채움
- 프론트 `pages/admin/DashboardPage` — KPI 카드 4개 + Timeline sparkline + 카테고리 막대 + 실시간 로그 스트림 + 최근 공지 리스트
- 차트는 외부 라이브러리 없이 인라인 SVG / div 너비로 구현
- 헤더에 진입 아이콘 추가 (Refresh)

## 검색 결과/컨텍스트 확인 패널 (답변 근거 투명 공개)
- 백엔드 rag.run_hybrid_rag 가 vector_docs/graph_relations/context 를 retrieval payload 로 같이 반환
- 백엔드 SSE 에 `retrieval` 청크 추가 (text → sources → graph → retrieval → done)
- DB Message 모델에 retrieval_json 컬럼 추가 + 마이그레이션 (과거 대화도 클릭하면 검색 과정 복원)
- 프론트 `RetrievalDebugPanel` 신규 — 3탭 (Vector 결과 / Graph 결과 / LLM 컨텍스트)
- MessageBubble 답변 하단 "🔍 검색 과정 보기" 토글
- types.message.StreamChunkType 에 'retrieval' 추가, RetrievalDebug 타입 신규

## 공통
- chat.api.constant.ts: stats/crawlLogs 엔드포인트 추가
- App.tsx: 'admin' view 라우팅 추가

## 🎯 작업 내용



## 📝 변경 사항



## 🔗 관련 이슈



## ✅ 체크리스트
- [ ] 코드가 컨벤션을 따르고 있나요?
- [ ] 불필요한 콘솔 로그를 제거했나요?
- [ ] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added admin dashboard for monitoring data collection status with KPI metrics, timeline, and category distribution
  * Added retrieval debug panel showing search process details (vector results, graph relations, LLM context)
  * Added stats and crawl logs API endpoints for real-time monitoring
  * Added sync status logging to track data collection progress and errors

* **Improvements**
  * Changed database update strategy from rebuild to incremental updates for better performance
  * Enhanced message persistence to store and display search retrieval information

* **Bug Fixes**
  * Fixed missing database schema column for retrieval data storage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->