### PR TITLE
[REFACTOR] 프론트엔드 전체 리팩토링

### DIFF
--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -2,7 +2,7 @@
 // 라우팅이 별도 라이브러리 없이 간단해서 useState 한 줄로 토글.
 // 추후 React Router 도입 시 `<Routes>` 로 교체하면 됨.
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { ChatPage } from '@/pages/chat';
 import { SettingsPage } from '@/pages/settings/SettingsPage';
 import { DashboardPage } from '@/pages/admin';
@@ -10,8 +10,21 @@ import { ErrorBoundary } from '@/components/common/ErrorBoundary';
 
 type View = 'chat' | 'settings' | 'admin';
 
+const VIEW_STORAGE_KEY = 'cheongdam:view';
+
+function getInitialView(): View {
+  const saved = typeof window !== 'undefined' ? localStorage.getItem(VIEW_STORAGE_KEY) : null;
+  return saved === 'settings' || saved === 'admin' ? saved : 'chat';
+}
+
 export function App() {
-  const [view, setView] = useState<View>('chat');
+  const [view, setView] = useState<View>(getInitialView);
+
+  // 새로고침해도 설정/관리자 화면에 머물러 있도록 마지막 화면을 저장.
+  useEffect(() => {
+    localStorage.setItem(VIEW_STORAGE_KEY, view);
+  }, [view]);
+
   const goChat = () => setView('chat');
   return (
     <ErrorBoundary>

--- a/front/src/components/chat/ChatInput.tsx
+++ b/front/src/components/chat/ChatInput.tsx
@@ -53,7 +53,7 @@ export function ChatInput({ isStreaming, onSend, onAbort }: Props) {
           onChange={(e) => setValue(e.target.value)}
           onKeyDown={onKey}
           rows={1}
-          placeholder="청담에게 학교 공지사항을 물어보세요..."
+          placeholder="청담에게 학교 공지사항을 물어보세요"
           disabled={isStreaming}
           className="min-h-6 flex-1 resize-none border-0 bg-transparent py-2 text-[14.5px]
                      leading-relaxed text-ink outline-none placeholder:text-ink-4
@@ -84,8 +84,7 @@ export function ChatInput({ isStreaming, onSend, onAbort }: Props) {
       </div>
       <div className="mt-2 text-center text-[11px] text-ink-4">
         <b className="font-semibold text-ink-3">Shift+Enter</b>로 줄바꿈, <b className="font-semibold text-ink-3">Enter</b>로 전송 ·
-        청담은 출처가 있는 답변만 드려요 <span className="text-brand-500">·</span>{' '}
-        <span className="font-medium text-brand-500">Hybrid RAG</span>
+        청담은 출처가 있는 답변만 드려요
       </div>
     </div>
   );

--- a/front/src/components/chat/MessageBubble.tsx
+++ b/front/src/components/chat/MessageBubble.tsx
@@ -84,6 +84,7 @@ export function MessageBubble({
                 'text-[14.5px] leading-relaxed text-ink',
                 'prose prose-sm max-w-none prose-strong:font-semibold',
                 msg.isError && 'border-red-200 bg-red-50/60 text-red-900',
+                msg.isStopped && 'border-line-2 bg-canvas text-ink-3 italic',
               )}
             >
               <Markdown>{msg.content || ' '}</Markdown>
@@ -102,7 +103,7 @@ export function MessageBubble({
               </button>
             )}
 
-            {!msg.streaming && !msg.isError && (
+            {!msg.streaming && !msg.isError && !msg.isStopped && (
               <div className="flex items-center gap-1 group">
                 <span className="text-[11px] text-ink-4 px-1">{msg.createdAt}</span>
                 <div className="transition-opacity sm:opacity-0 sm:group-hover:opacity-100">

--- a/front/src/components/chat/MessageList.tsx
+++ b/front/src/components/chat/MessageList.tsx
@@ -30,7 +30,7 @@ export function MessageList(props: Props) {
   };
 
   return (
-    <div ref={ref} className="flex-1 overflow-y-auto">
+    <div ref={ref} className="flex-1 min-h-0 overflow-y-auto">
       <div className="mx-auto flex w-full max-w-[820px] flex-col gap-4 px-4 pb-8 pt-7 sm:px-6">
         {messages.map((m) => (
           <MessageBubble

--- a/front/src/components/chat/RAGPipeline.tsx
+++ b/front/src/components/chat/RAGPipeline.tsx
@@ -44,10 +44,8 @@ export function RAGPipeline({ stepIdx }: Props) {
                 <span className="block h-1.5 w-1.5 rounded-full bg-current" />
               )}
             </span>
+            <span className="text-ink-4">···</span>
             <span className="flex-1">{s.label}</span>
-            <span className="rounded bg-canvas px-1.5 py-0.5 font-mono text-[11px] text-ink-4">
-              {s.tag}
-            </span>
           </div>
         );
       })}

--- a/front/src/components/chat/WelcomeScreen.tsx
+++ b/front/src/components/chat/WelcomeScreen.tsx
@@ -11,8 +11,9 @@ interface Props {
 
 export function WelcomeScreen({ onPick }: Props) {
   return (
-    <div className="mx-auto flex w-full max-w-[820px] flex-1 flex-col items-center
-                    justify-center px-6 pb-6 pt-10 text-center">
+    <div className="flex-1 min-h-0 overflow-y-auto">
+      <div className="mx-auto flex w-full max-w-[820px] min-h-full flex-col items-center
+                      justify-center px-6 pb-6 pt-10 text-center">
       <div className="mb-5"><CDLogo size="lg" /></div>
       <h1 className="m-0 mb-2.5 text-[32px] font-bold leading-tight tracking-tight text-ink">
         무엇이 궁금하세요?
@@ -46,6 +47,7 @@ export function WelcomeScreen({ onPick }: Props) {
             </button>
           );
         })}
+      </div>
       </div>
     </div>
   );

--- a/front/src/components/common/CDLogo.tsx
+++ b/front/src/components/common/CDLogo.tsx
@@ -7,13 +7,13 @@ import { cn } from '@/utils/cn';
 export type LogoVariant = 'drop-ripple' | 'star-drop' | 'cheong';
 
 interface Props {
-  size?: 'sm' | 'md' | 'lg';
+  size?: 'sm' | 'header' | 'md' | 'lg';
   variant?: LogoVariant;
   animated?: boolean;
   className?: string;
 }
 
-const SIZE_CLASS = { sm: 'w-8 h-8', md: 'w-12 h-12', lg: 'w-24 h-24' };
+const SIZE_CLASS = { sm: 'w-8 h-8', header: 'w-10 h-10', md: 'w-12 h-12', lg: 'w-24 h-24' };
 
 export function CDLogo({
   size = 'md', variant = 'drop-ripple', animated = true, className,

--- a/front/src/components/common/Icon.tsx
+++ b/front/src/components/common/Icon.tsx
@@ -1,7 +1,3 @@
-// components/common/Icon.tsx
-// 청담 — 사용처별 인라인 SVG 아이콘 세트.
-// Lucide 스타일(1.5px stroke, round caps) — 패키지 의존 없이 직접 그림.
-
 import type { SVGProps } from 'react';
 
 type Props = SVGProps<SVGSVGElement>;
@@ -40,6 +36,7 @@ export const Icon = {
   Stop:       filled(<rect x={6} y={6} width={12} height={12} rx={2} />),
   Search:     stroke(<><circle cx={11} cy={11} r={8} /><path d="m21 21-4.3-4.3" /></>),
   Menu:       stroke(<path d="M3 12h18M3 6h18M3 18h18" />),
+  Sidebar:    stroke(<><rect x={3} y={3} width={18} height={18} rx={2} /><path d="M9 3v18" /></>),
   Settings:   stroke(<><circle cx={12} cy={12} r={3} /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09a1.65 1.65 0 0 0-1-1.51 1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></>),
   Chat:       stroke(<path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />),
   Bookmark:   stroke(<path d="m19 21-7-4-7 4V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />),

--- a/front/src/components/common/Toast.tsx
+++ b/front/src/components/common/Toast.tsx
@@ -19,9 +19,9 @@ export function Toast({ message, show, onHide, duration = 2000 }: Props) {
     <div
       role="status"
       aria-live="polite"
-      className={`pointer-events-none fixed bottom-3 left-1/2 z-[60] -translate-x-1/2
+      className={`pointer-events-none fixed top-4 left-1/2 z-[60] -translate-x-1/2
                  transition-all duration-300
-                 ${show ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'}`}
+                 ${show ? 'translate-y-0 opacity-100' : '-translate-y-2 opacity-0'}`}
     >
       <div className="flex items-center gap-2 rounded-full bg-brand-grad px-4 py-2.5
                       text-[13px] font-medium text-white shadow-brand-glow">

--- a/front/src/components/common/Toast.tsx
+++ b/front/src/components/common/Toast.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { Icon } from './Icon';
 
 interface Props {
@@ -9,11 +9,17 @@ interface Props {
 }
 
 export function Toast({ message, show, onHide, duration = 2000 }: Props) {
+  const onHideRef = useRef(onHide);
+
+  useEffect(() => {
+    onHideRef.current = onHide;
+  }, [onHide]);
+  
   useEffect(() => {
     if (!show) return;
-    const timer = setTimeout(onHide, duration);
+    const timer = setTimeout(() => onHideRef.current(), duration);
     return () => clearTimeout(timer);
-  }, [show, duration, onHide]);
+  }, [show, duration]);
 
   return (
     <div

--- a/front/src/components/common/Toast.tsx
+++ b/front/src/components/common/Toast.tsx
@@ -1,0 +1,33 @@
+import { useEffect } from 'react';
+import { Icon } from './Icon';
+
+interface Props {
+  message: string;
+  show: boolean;
+  onHide: () => void;
+  duration?: number;
+}
+
+export function Toast({ message, show, onHide, duration = 2000 }: Props) {
+  useEffect(() => {
+    if (!show) return;
+    const timer = setTimeout(onHide, duration);
+    return () => clearTimeout(timer);
+  }, [show, duration, onHide]);
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`pointer-events-none fixed bottom-3 left-1/2 z-[60] -translate-x-1/2
+                 transition-all duration-300
+                 ${show ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'}`}
+    >
+      <div className="flex items-center gap-2 rounded-full bg-brand-grad px-4 py-2.5
+                      text-[13px] font-medium text-white shadow-brand-glow">
+        <Icon.Check className="text-white" />
+        {message}
+      </div>
+    </div>
+  );
+}

--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -35,10 +35,10 @@ export function Header({ onOpenAdmin }: Props) {
             <button
               onClick={() => setSidebarOpen(true)}
               aria-label="사이드바 열기"
-              className="group relative flex h-8 w-8 flex-shrink-0 items-center justify-center cursor-pointer"
+              className="group relative flex h-10 w-10 flex-shrink-0 items-center justify-center cursor-pointer"
             >
               <span className="transition-opacity group-hover:opacity-0">
-                <CDLogo size="sm" />
+                <CDLogo size="header" />
               </span>
               <span className="absolute inset-0 flex items-center justify-center text-ink-2
                                 opacity-0 transition-opacity group-hover:opacity-100">
@@ -46,10 +46,10 @@ export function Header({ onOpenAdmin }: Props) {
               </span>
             </button>
             <div className="flex flex-col leading-tight">
-              <span className="text-[14.5px] font-semibold text-ink">
-                청담 <span className="ml-1 text-[12px] font-medium text-ink-4">淸潭</span>
+              <span className="text-[16px] font-semibold text-ink">
+                청담 <span className="ml-1 text-[14px] font-medium text-ink-4">淸潭</span>
               </span>
-              <span className="mt-0.5 hidden text-[11.5px] text-ink-3 sm:block">
+              <span className="mt-0.5 hidden text-[12px] text-ink-3 sm:block">
                 경북대학교 공지사항 어시스턴트
               </span>
             </div>

--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
-// components/layout/Header.tsx
 // 상단바 — 사이드바 토글, 로고+타이틀, 마지막 동기화, 지식 그래프, 공유
 
+import { useState } from 'react';
 import { IconButton } from '@/components/common/IconButton';
 import { Button } from '@/components/common/Button';
 import { Icon } from '@/components/common/Icon';
@@ -19,7 +19,19 @@ interface Props {
 export function Header({ onOpenGraph, onOpenAdmin, onOpenSettings }: Props) {
   const toggleSidebar = useSidebarStore((s) => s.toggleSidebar);
   const hasMessages = useChatStore((s) => s.messages.length > 0);
+  const resetChat = useChatStore((s) => s.resetChat);
   const { meta } = useAnnouncements();
+  const [copied, setCopied] = useState(false);
+
+  const handleShare = async () => {
+    try {
+      await navigator.clipboard.writeText(window.location.href);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      /* noop */
+    }
+  };
 
   return (
     <header className="flex flex-shrink-0 items-center justify-between border-b border-line
@@ -28,13 +40,15 @@ export function Header({ onOpenGraph, onOpenAdmin, onOpenSettings }: Props) {
         <IconButton aria-label="사이드바 토글" onClick={toggleSidebar}>
           <Icon.Menu />
         </IconButton>
-        <CDLogo size="sm" />
+        <button onClick={resetChat} aria-label="메인 화면으로 이동" className="cursor-pointer">
+          <CDLogo size="sm" />
+        </button>
         <div className="flex flex-col leading-tight">
           <span className="text-[14.5px] font-semibold text-ink">
             청담 <span className="ml-1 text-[12px] font-medium text-ink-4">淸潭</span>
           </span>
           <span className="mt-0.5 hidden text-[11.5px] text-ink-3 sm:block">
-            경북대학교 공지사항 하이브리드 RAG 어시스턴트
+            경북대학교 공지사항 어시스턴트
           </span>
         </div>
       </div>
@@ -62,7 +76,9 @@ export function Header({ onOpenGraph, onOpenAdmin, onOpenSettings }: Props) {
             <Icon.Settings />
           </IconButton>
         )}
-        <Button variant="pill" leadingIcon={<Icon.Share />}>공유</Button>
+        <Button variant="pill" leadingIcon={<Icon.Share />} onClick={handleShare}>
+          {copied ? '복사됨' : '공유'}
+        </Button>
       </div>
     </header>
   );

--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -5,6 +5,7 @@ import { IconButton } from '@/components/common/IconButton';
 import { Button } from '@/components/common/Button';
 import { Icon } from '@/components/common/Icon';
 import { CDLogo } from '@/components/common/CDLogo';
+import { Toast } from '@/components/common/Toast';
 import { useSidebarStore } from '@/store/sidebarStore';
 import { useChatStore } from '@/store/chatStore';
 import { useAnnouncements } from '@/hooks/useAnnouncements';
@@ -21,13 +22,12 @@ export function Header({ onOpenGraph, onOpenAdmin, onOpenSettings }: Props) {
   const hasMessages = useChatStore((s) => s.messages.length > 0);
   const resetChat = useChatStore((s) => s.resetChat);
   const { meta } = useAnnouncements();
-  const [copied, setCopied] = useState(false);
+  const [showToast, setShowToast] = useState(false);
 
   const handleShare = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1500);
+      setShowToast(true);
     } catch {
       /* noop */
     }
@@ -77,9 +77,15 @@ export function Header({ onOpenGraph, onOpenAdmin, onOpenSettings }: Props) {
           </IconButton>
         )}
         <Button variant="pill" leadingIcon={<Icon.Share />} onClick={handleShare}>
-          {copied ? '복사됨' : '공유'}
+          공유
         </Button>
       </div>
+
+      <Toast
+        message="링크가 복사되었습니다"
+        show={showToast}
+        onHide={() => setShowToast(false)}
+      />
     </header>
   );
 }

--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -1,5 +1,3 @@
-// 상단바 — 사이드바 토글, 로고+타이틀, 마지막 동기화, 지식 그래프, 공유
-
 import { useState } from 'react';
 import { IconButton } from '@/components/common/IconButton';
 import { Button } from '@/components/common/Button';
@@ -7,20 +5,16 @@ import { Icon } from '@/components/common/Icon';
 import { CDLogo } from '@/components/common/CDLogo';
 import { Toast } from '@/components/common/Toast';
 import { useSidebarStore } from '@/store/sidebarStore';
-import { useChatStore } from '@/store/chatStore';
 import { useAnnouncements } from '@/hooks/useAnnouncements';
 import { formatSyncTime } from '@/utils/formatDate';
 
 interface Props {
-  onOpenGraph: () => void;
   onOpenAdmin?: () => void;
-  onOpenSettings?: () => void;
 }
 
-export function Header({ onOpenGraph, onOpenAdmin, onOpenSettings }: Props) {
-  const toggleSidebar = useSidebarStore((s) => s.toggleSidebar);
-  const hasMessages = useChatStore((s) => s.messages.length > 0);
-  const resetChat = useChatStore((s) => s.resetChat);
+export function Header({ onOpenAdmin }: Props) {
+  const isSidebarOpen = useSidebarStore((s) => s.isOpen);
+  const setSidebarOpen = useSidebarStore((s) => s.setSidebarOpen);
   const { meta } = useAnnouncements();
   const [showToast, setShowToast] = useState(false);
 
@@ -34,46 +28,46 @@ export function Header({ onOpenGraph, onOpenAdmin, onOpenSettings }: Props) {
   };
 
   return (
-    <header className="flex flex-shrink-0 items-center justify-between border-b border-line
-                       bg-white/70 px-3 py-3.5 backdrop-blur-md sm:px-6">
+    <header className="flex flex-shrink-0 items-center justify-between bg-canvas px-3 py-3.5 sm:px-6">
       <div className="flex items-center gap-3.5">
-        <IconButton aria-label="사이드바 토글" onClick={toggleSidebar}>
-          <Icon.Menu />
-        </IconButton>
-        <button onClick={resetChat} aria-label="메인 화면으로 이동" className="cursor-pointer">
-          <CDLogo size="sm" />
-        </button>
-        <div className="flex flex-col leading-tight">
-          <span className="text-[14.5px] font-semibold text-ink">
-            청담 <span className="ml-1 text-[12px] font-medium text-ink-4">淸潭</span>
-          </span>
-          <span className="mt-0.5 hidden text-[11.5px] text-ink-3 sm:block">
-            경북대학교 공지사항 어시스턴트
-          </span>
-        </div>
+        {!isSidebarOpen && (
+          <>
+            <button
+              onClick={() => setSidebarOpen(true)}
+              aria-label="사이드바 열기"
+              className="group relative flex h-8 w-8 flex-shrink-0 items-center justify-center cursor-pointer"
+            >
+              <span className="transition-opacity group-hover:opacity-0">
+                <CDLogo size="sm" />
+              </span>
+              <span className="absolute inset-0 flex items-center justify-center text-ink-2
+                                opacity-0 transition-opacity group-hover:opacity-100">
+                <Icon.Sidebar />
+              </span>
+            </button>
+            <div className="flex flex-col leading-tight">
+              <span className="text-[14.5px] font-semibold text-ink">
+                청담 <span className="ml-1 text-[12px] font-medium text-ink-4">淸潭</span>
+              </span>
+              <span className="mt-0.5 hidden text-[11.5px] text-ink-3 sm:block">
+                경북대학교 공지사항 어시스턴트
+              </span>
+            </div>
+          </>
+        )}
       </div>
 
       <div className="flex items-center gap-2">
         {meta && (
           <div className="hidden items-center gap-1.5 whitespace-nowrap text-[11.5px] text-ink-3 sm:flex">
             <span className="block h-1.5 w-1.5 rounded-full bg-emerald-500
-                             shadow-[0_0_0_3px_rgba(16,185,129,0.15)]" />
+                              shadow-[0_0_0_3px_rgba(16,185,129,0.15)]" />
             마지막 동기화 {formatSyncTime(meta.lastCrawledAt)}
           </div>
-        )}
-        {hasMessages && (
-          <Button variant="pill" leadingIcon={<Icon.Graph />} onClick={onOpenGraph}>
-            지식 그래프
-          </Button>
         )}
         {onOpenAdmin && (
           <IconButton aria-label="데이터 수집 모니터링" onClick={onOpenAdmin}>
             <Icon.Refresh />
-          </IconButton>
-        )}
-        {onOpenSettings && (
-          <IconButton aria-label="설정" onClick={onOpenSettings}>
-            <Icon.Settings />
           </IconButton>
         )}
         <Button variant="pill" leadingIcon={<Icon.Share />} onClick={handleShare}>

--- a/front/src/components/layout/Header.tsx
+++ b/front/src/components/layout/Header.tsx
@@ -17,13 +17,16 @@ export function Header({ onOpenAdmin }: Props) {
   const setSidebarOpen = useSidebarStore((s) => s.setSidebarOpen);
   const { meta } = useAnnouncements();
   const [showToast, setShowToast] = useState(false);
+  const [toastMessage, setToastMessage] = useState('링크가 복사되었습니다');
 
   const handleShare = async () => {
     try {
       await navigator.clipboard.writeText(window.location.href);
+      setToastMessage('링크가 복사되었습니다');
       setShowToast(true);
     } catch {
-      /* noop */
+      setToastMessage('링크 복사에 실패했습니다');
+      setShowToast(true);
     }
   };
 
@@ -76,7 +79,7 @@ export function Header({ onOpenAdmin }: Props) {
       </div>
 
       <Toast
-        message="링크가 복사되었습니다"
+        message={toastMessage}
         show={showToast}
         onHide={() => setShowToast(false)}
       />

--- a/front/src/components/layout/Sidebar.tsx
+++ b/front/src/components/layout/Sidebar.tsx
@@ -1,8 +1,7 @@
-// 대화 히스토리 + 보관함 사이드바.
-
 import { useMemo } from 'react';
 import { CDLogo } from '@/components/common/CDLogo';
 import { Icon } from '@/components/common/Icon';
+import { IconButton } from '@/components/common/IconButton';
 import { useSidebarStore } from '@/store/sidebarStore';
 import { useChatStore } from '@/store/chatStore';
 import { useChatHistory } from '@/hooks/useChatHistory';
@@ -14,7 +13,9 @@ interface Props {
 }
 
 export function Sidebar({ onOpenSettings }: Props) {
-  const { isOpen, activeTab, setActiveTab, bookmarks, selectedSessionId, setSidebarOpen } = useSidebarStore();
+  const {
+    isOpen, activeTab, setActiveTab, bookmarks, selectedSessionId, setSidebarOpen,
+  } = useSidebarStore();
   const resetChat = useChatStore((s) => s.resetChat);
 
   const closeMobile = () => { if (window.innerWidth < 640) setSidebarOpen(false); };
@@ -26,13 +27,10 @@ export function Sidebar({ onOpenSettings }: Props) {
     <aside
       className={cn(
         'flex w-[280px] flex-col border-r border-line bg-white',
-        // Mobile: fixed overlay so it doesn't push the chat area off-screen
         'fixed inset-y-0 left-0 z-[50]',
         'transition-[transform,opacity] duration-200',
-        // Desktop (≥640px): back to in-flow flex sibling
         'sm:relative sm:z-[1] sm:flex-shrink-0',
         'sm:transition-[margin,opacity]',
-        // Closed: translate off on mobile, margin-shift on desktop
         !isOpen && '-translate-x-full opacity-0 sm:translate-x-0 sm:-ml-[280px]',
       )}
       aria-hidden={!isOpen || undefined}
@@ -43,12 +41,15 @@ export function Sidebar({ onOpenSettings }: Props) {
         <button onClick={resetChat} aria-label="메인 화면으로 이동" className="cursor-pointer">
           <CDLogo size="sm" />
         </button>
-        <div className="flex flex-col leading-tight">
+        <div className="flex flex-1 flex-col leading-tight">
           <span className="text-[17px] font-bold text-ink">
             청담<span className="ml-1.5 text-[11px] font-medium text-ink-4 tracking-wide">淸潭</span>
           </span>
           <span className="mt-0.5 text-[11px] text-ink-3">경북대 공지 어시스턴트</span>
         </div>
+        <IconButton aria-label="사이드바 닫기" onClick={() => setSidebarOpen(false)}>
+          <Icon.Sidebar />
+        </IconButton>
       </div>
 
       {/* New chat */}
@@ -57,8 +58,8 @@ export function Sidebar({ onOpenSettings }: Props) {
           type="button"
           onClick={() => { resetChat(); closeMobile(); }}
           className="flex w-full items-center gap-2.5 rounded-cd-md bg-brand-grad
-                     px-3.5 py-2.5 text-left text-[13.5px] font-semibold text-white
-                     shadow-brand-glow transition-transform hover:-translate-y-px"
+                      px-3.5 py-2.5 text-left text-[13.5px] font-semibold text-white
+                      shadow-brand-glow transition-transform hover:-translate-y-px"
         >
           <Icon.Plus />
           <span>새로운 채팅</span>
@@ -117,7 +118,7 @@ export function Sidebar({ onOpenSettings }: Props) {
                       onClick={(e) => { e.stopPropagation(); void deleteSession(s.id); }}
                       role="button" aria-label="대화 삭제"
                       className="flex cursor-pointer rounded p-1 text-ink-4 hover:bg-red-100
-                                 hover:text-red-500 sm:hidden sm:group-hover:flex"
+                                  hover:text-red-500 sm:hidden sm:group-hover:flex"
                     >
                       <Icon.Trash />
                     </span>

--- a/front/src/components/layout/Sidebar.tsx
+++ b/front/src/components/layout/Sidebar.tsx
@@ -38,7 +38,7 @@ export function Sidebar({ onOpenSettings }: Props) {
     >
       {/* Brand */}
       <div className="flex items-center gap-2.5 px-4 pb-3 pt-4">
-        <button onClick={resetChat} aria-label="메인 화면으로 이동" className="cursor-pointer">
+        <button onClick={() => { resetChat(); closeMobile(); }} aria-label="메인 화면으로 이동" className="cursor-pointer">
           <CDLogo size="sm" />
         </button>
         <div className="flex flex-1 flex-col leading-tight">

--- a/front/src/components/layout/Sidebar.tsx
+++ b/front/src/components/layout/Sidebar.tsx
@@ -1,4 +1,3 @@
-// components/layout/Sidebar.tsx
 // 대화 히스토리 + 보관함 사이드바.
 
 import { useMemo } from 'react';
@@ -16,7 +15,7 @@ interface Props {
 
 export function Sidebar({ onOpenSettings }: Props) {
   const { isOpen, activeTab, setActiveTab, bookmarks, selectedSessionId, setSidebarOpen } = useSidebarStore();
-  const { resetChat } = useChatStore();
+  const resetChat = useChatStore((s) => s.resetChat);
 
   const closeMobile = () => { if (window.innerWidth < 640) setSidebarOpen(false); };
   const { sessions, openSession, deleteSession } = useChatHistory();
@@ -41,7 +40,9 @@ export function Sidebar({ onOpenSettings }: Props) {
     >
       {/* Brand */}
       <div className="flex items-center gap-2.5 px-4 pb-3 pt-4">
-        <CDLogo size="sm" />
+        <button onClick={resetChat} aria-label="메인 화면으로 이동" className="cursor-pointer">
+          <CDLogo size="sm" />
+        </button>
         <div className="flex flex-col leading-tight">
           <span className="text-[17px] font-bold text-ink">
             청담<span className="ml-1.5 text-[11px] font-medium text-ink-4 tracking-wide">淸潭</span>

--- a/front/src/components/layout/Sidebar.tsx
+++ b/front/src/components/layout/Sidebar.tsx
@@ -42,10 +42,9 @@ export function Sidebar({ onOpenSettings }: Props) {
           <CDLogo size="sm" />
         </button>
         <div className="flex flex-1 flex-col leading-tight">
-          <span className="text-[17px] font-bold text-ink">
-            청담<span className="ml-1.5 text-[11px] font-medium text-ink-4 tracking-wide">淸潭</span>
+          <span className="text-[18px] font-bold text-ink">
+            청담<span className="ml-1.5 text-[14px] font-medium text-ink-4 tracking-wide">淸潭</span>
           </span>
-          <span className="mt-0.5 text-[11px] text-ink-3">경북대 공지 어시스턴트</span>
         </div>
         <IconButton aria-label="사이드바 닫기" onClick={() => setSidebarOpen(false)}>
           <Icon.Sidebar />

--- a/front/src/hooks/useChat.ts
+++ b/front/src/hooks/useChat.ts
@@ -1,6 +1,4 @@
-// hooks/useChat.ts
 // 메시지 전송 + 스트리밍 청크 라우팅 + 중단(abort).
-// (PRD F-CHAT-02 / F-CHAT-05 / F-INPUT-04 / F-UX-04)
 
 import { useCallback, useRef } from 'react';
 import { useChatStore } from '@/store/chatStore';
@@ -46,7 +44,6 @@ export function useChat() {
         isLoading: true,
       });
 
-      // AbortController 등록
       const ctrl = new AbortController();
       setAbortController(ctrl);
       setStreaming(true);
@@ -61,8 +58,6 @@ export function useChat() {
           sessionId: useChatStore.getState().sessionId,
           message: normalized,
           signal: ctrl.signal,
-          // mock 라우터에 추천 카드 ID 힌트를 전달하려면 클로저로 외부 변수 캡쳐
-          // (실 서버에서는 무시)
           // @ts-expect-error — questionId는 mock 전용 비표준 필드
           questionId,
           onChunk: (chunk: StreamChunk) => routeChunk(chunk),
@@ -70,7 +65,6 @@ export function useChat() {
       } catch (err) {
         const isAbort = (err as Error)?.name === 'AbortError';
         if (!isAbort) {
-          // 인라인 에러 메시지 — F-UX-03
           updateMessage(assistantBornYet ? assistantId : loadingId, {
             isLoading: false,
             streaming: false,
@@ -95,7 +89,6 @@ export function useChat() {
           }
           case 'text': {
             if (!assistantBornYet) {
-              // 첫 토큰 — 로딩 버블을 실제 답변 버블로 전환
               removeMessage(loadingId);
               addMessage({
                 id: assistantId,
@@ -145,11 +138,27 @@ export function useChat() {
 
   const abort = useCallback(() => {
     abortController?.abort();
+
+    const messages = useChatStore.getState().messages;
+    const pending = [...messages].reverse().find((m) => m.isLoading || m.streaming);
+    if (pending) {
+      if (pending.isLoading && !pending.content) {
+        updateMessage(pending.id, {
+          isLoading: false,
+          streaming: false,
+          isStopped: true,
+          content: '답변 생성이 중지되었습니다.',
+          createdAt: formatMessageTime(),
+        });
+      } else {
+        updateMessage(pending.id, { isLoading: false, streaming: false });
+      }
+    }
+
     setStreaming(false);
     setRagStep(0);
-  }, [abortController, setStreaming, setRagStep]);
+  }, [abortController, removeMessage, updateMessage, setStreaming, setRagStep]);
 
-  /** 마지막 사용자 메시지를 다시 전송 — 에러 재시도용 (F-UX-04) */
   const retryLast = useCallback(() => {
     const last = useChatStore.getState().lastUserMessage;
     if (last) void send(last);

--- a/front/src/pages/chat/ChatPage.tsx
+++ b/front/src/pages/chat/ChatPage.tsx
@@ -1,8 +1,4 @@
-// pages/chat/ChatPage.tsx
-// 메인 챗봇 화면 — Welcome / MessageList / Composer + 모달 레이어.
-// UI 조립만 담당 (PRD 규칙). 상태는 store, 로직은 hooks 에서.
-
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Header } from '@/components/layout/Header';
 import { Sidebar } from '@/components/layout/Sidebar';
 import { WelcomeScreen } from '@/components/chat/WelcomeScreen';
@@ -48,16 +44,6 @@ export function ChatPage({ onOpenSettings, onOpenAdmin }: Props) {
     return () => window.removeEventListener('cd:bookmark', handler);
   }, [addBookmark, removeBookmark, sessionId]);
 
-  const handleOpenTopicGraph = useCallback(() => {
-    // 최신 답변 메시지의 graphData(백엔드 동적) 또는 graphKey(legacy/mock).
-    // 둘 다 없으면 'general' 더미 표시.
-    const lastWithGraph = [...messages].reverse().find(
-      (m) => m.graphData || m.graphKey,
-    );
-    setGraphData(lastWithGraph?.graphData ?? null);
-    setGraphKey(lastWithGraph?.graphData ? null : lastWithGraph?.graphKey ?? 'general');
-  }, [messages]);
-
   const closeGraphModal = () => {
     setGraphKey(null);
     setGraphData(null);
@@ -70,7 +56,7 @@ export function ChatPage({ onOpenSettings, onOpenAdmin }: Props) {
       <div className="pointer-events-none absolute inset-0 z-0"
            style={{
              backgroundImage:
-               'radial-gradient(ellipse 800px 400px at 80% 10%, rgba(91, 174, 220, 0.08), transparent 60%),' +
+               'radial-gradient(ellipse 800px 400px at 80% 25%, rgba(91, 174, 220, 0), transparent 60%),' +
                'radial-gradient(ellipse 600px 500px at 15% 95%, rgba(37, 99, 235, 0.05), transparent 60%)',
            }} />
       {isSidebarOpen && (
@@ -81,11 +67,7 @@ export function ChatPage({ onOpenSettings, onOpenAdmin }: Props) {
       )}
       <Sidebar onOpenSettings={onOpenSettings} />
       <main className="relative z-[1] flex min-w-0 min-h-0 flex-1 flex-col">
-        <Header
-          onOpenGraph={handleOpenTopicGraph}
-          onOpenAdmin={onOpenAdmin}
-          onOpenSettings={onOpenSettings}
-        />
+        <Header onOpenAdmin={onOpenAdmin} />
         {isWelcome ? (
           <WelcomeScreen onPick={(q) => void send(q.title, q.id)} />
         ) : (

--- a/front/src/pages/chat/ChatPage.tsx
+++ b/front/src/pages/chat/ChatPage.tsx
@@ -80,7 +80,7 @@ export function ChatPage({ onOpenSettings, onOpenAdmin }: Props) {
         />
       )}
       <Sidebar onOpenSettings={onOpenSettings} />
-      <main className="relative z-[1] flex min-w-0 flex-1 flex-col">
+      <main className="relative z-[1] flex min-w-0 min-h-0 flex-1 flex-col">
         <Header
           onOpenGraph={handleOpenTopicGraph}
           onOpenAdmin={onOpenAdmin}

--- a/front/src/store/chatStore.ts
+++ b/front/src/store/chatStore.ts
@@ -3,6 +3,7 @@
 // (PRD 9-1)
 
 import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
 import type { Message } from '@/types/message.type';
 import type { AnnouncementSource } from '@/types/announcement.type';
 
@@ -45,52 +46,78 @@ const initialState: ChatState = {
   lastUserMessage: null,
 };
 
-export const useChatStore = create<ChatState & ChatActions>((set) => ({
-  ...initialState,
+export const useChatStore = create<ChatState & ChatActions>()(
+  persist(
+    (set) => ({
+      ...initialState,
 
-  setSessionId: (id) => set({ sessionId: id }),
+      setSessionId: (id) => set({ sessionId: id }),
 
-  addMessage: (message) =>
-    set((s) => ({ messages: [...s.messages, message] })),
+      addMessage: (message) =>
+        set((s) => ({ messages: [...s.messages, message] })),
 
-  updateMessage: (id, patch) =>
-    set((s) => ({
-      messages: s.messages.map((m) => (m.id === id ? { ...m, ...patch } : m)),
-    })),
+      updateMessage: (id, patch) =>
+        set((s) => ({
+          messages: s.messages.map((m) => (m.id === id ? { ...m, ...patch } : m)),
+        })),
 
-  removeMessage: (id) =>
-    set((s) => ({ messages: s.messages.filter((m) => m.id !== id) })),
+      removeMessage: (id) =>
+        set((s) => ({ messages: s.messages.filter((m) => m.id !== id) })),
 
-  appendStreamChunk: (id, chunk) =>
-    set((s) => ({
-      messages: s.messages.map((m) =>
-        m.id === id ? { ...m, content: (m.content ?? '') + chunk } : m,
-      ),
-    })),
+      appendStreamChunk: (id, chunk) =>
+        set((s) => ({
+          messages: s.messages.map((m) =>
+            m.id === id ? { ...m, content: (m.content ?? '') + chunk } : m,
+          ),
+        })),
 
-  finalizeStream: (id, payload) =>
-    set((s) => ({
-      messages: s.messages.map((m) =>
-        m.id === id
-          ? { ...m, ...payload, streaming: false, isLoading: false }
-          : m,
-      ),
-      isStreaming: false,
-      ragStep: 0,
-    })),
+      finalizeStream: (id, payload) =>
+        set((s) => ({
+          messages: s.messages.map((m) =>
+            m.id === id
+              ? { ...m, ...payload, streaming: false, isLoading: false }
+              : m,
+          ),
+          isStreaming: false,
+          ragStep: 0,
+        })),
 
-  toggleBookmark: (id) =>
-    set((s) => ({
-      messages: s.messages.map((m) =>
-        m.id === id ? { ...m, isBookmarked: !m.isBookmarked } : m,
-      ),
-    })),
+      toggleBookmark: (id) =>
+        set((s) => ({
+          messages: s.messages.map((m) =>
+            m.id === id ? { ...m, isBookmarked: !m.isBookmarked } : m,
+          ),
+        })),
 
-  setStreaming: (v) => set({ isStreaming: v }),
-  setRagStep: (n) => set({ ragStep: n }),
-  setAbortController: (c) => set({ abortController: c }),
-  setLastUserMessage: (msg) => set({ lastUserMessage: msg }),
+      setStreaming: (v) => set({ isStreaming: v }),
+      setRagStep: (n) => set({ ragStep: n }),
+      setAbortController: (c) => set({ abortController: c }),
+      setLastUserMessage: (msg) => set({ lastUserMessage: msg }),
 
-  loadSession: (sessionId, messages) => set({ sessionId, messages }),
-  resetChat: () => set({ ...initialState }),
-}));
+      loadSession: (sessionId, messages) => set({ sessionId, messages }),
+      resetChat: () => set({ ...initialState }),
+    }),
+    {
+      name: 'cheongdam:chat',
+      // 새로고침 시에도 대화가 유지되도록 메시지/세션만 영속화.
+      // 스트리밍 진행 상태(abortController 등)는 새로고침 후 의미가 없으므로 제외.
+      partialize: (s) => ({ sessionId: s.sessionId, messages: s.messages }),
+      // 스트리밍 도중 새로고침된 경우, 그대로 저장돼 있던 로딩/스트리밍
+      // 말풍선이 영원히 멈춘 것처럼 보이지 않도록 정리.
+      onRehydrateStorage: () => (state) => {
+        if (!state) return;
+        state.messages = state.messages.map((m) =>
+          m.isLoading || m.streaming
+            ? {
+                ...m,
+                isLoading: false,
+                streaming: false,
+                isStopped: !m.content,
+                content: m.content || '답변 생성이 중지되었습니다.',
+              }
+            : m,
+        );
+      },
+    },
+  ),
+);

--- a/front/src/types/message.type.ts
+++ b/front/src/types/message.type.ts
@@ -22,6 +22,8 @@ export interface Message {
   retrieval?: RetrievalDebug;
   createdAt: string;
   isError?: boolean;
+  /** UI-only 플래그 — 답변 생성 전(텍스트 0자) 상태에서 사용자가 중지함 */
+  isStopped?: boolean;
   isBookmarked?: boolean;
   /** UI-only 플래그 — 스트리밍 중 */
   streaming?: boolean;


### PR DESCRIPTION
## 🎯 작업 내용
프론트엔드 채팅 화면(헤더·사이드바·메시지) UX 전반을 개선했습니다. 분할 화면에서 스크롤이 안 되던 버그를 고치고, 헤더/사이드바의 중복 UI를 정리하고, 공유·답변 중지 등 기존 기능의 피드백을 보강했습니다.

## 📝 변경 사항

### 레이아웃 / 스크롤
- 분할 화면(좁은 뷰포트)에서 채팅 영역과 시작 전 웰컴 화면 모두 스크롤이 안 되던 문제 수정 (`min-h-0` 누락 등 flex 레이아웃 버그)

### 헤더 · 사이드바
- 헤더 로고 클릭 시 메인(웰컴) 화면으로 이동
- 헤더 로고에 마우스를 올리면 사이드바 아이콘으로 전환, 클릭하면 사이드바 열림 (호버 시 자동으로 열리지 않도록 조정)
- 사이드바 내부에 닫기 버튼 추가, 닫기 아이콘을 별도 제작한 `Icon.Sidebar`로 통일
- 헤더의 햄버거 메뉴 아이콘 제거 (로고 호버 동작과 중복)
- 사이드바가 열려 있을 때 헤더의 로고/타이틀 숨김 처리
- 헤더 배경색을 페이지 배경과 동일하게 맞추고 하단 구분선 제거
- 헤더의 "지식 그래프" 버튼 제거 — 답변별 인라인 그래프 기능과 중복
- 헤더의 "설정" 버튼 제거 — 사이드바 하단 설정 메뉴와 중복
- 헤더 로고 크기를 기존 32px → 40px로 확대 (다른 화면의 로고 크기는 유지)

### 공유 기능
- 헤더 "공유" 버튼 클릭 시 현재 페이지 링크를 클립보드에 복사
- 복사 완료 알림을 버튼 텍스트 변경 대신 토스트 컴포넌트로 표시
- 토스트 색상을 브랜드 컬러 톤에 맞게 조정
- 토스트 노출 위치를 화면 하단 → 상단으로 변경

### 답변 생성 중지
- "멈춤" 버튼 클릭 시 RAG 파이프라인 로딩 애니메이션이 계속 돌아가던 문제 수정 — 중지 즉시 로딩 인디케이터 정지
- 답변 텍스트가 생성되기 전에 중지한 경우, 말풍선이 사라지는 대신 "답변 생성이 중지되었습니다." 문구를 표시

### RAG 파이프라인 로딩 UI
- 진행 단계의 내부 식별자(태그) 노출 제거
- 단계 아이콘과 라벨 사이에 "···" 구분자 추가

### 채팅 상태 영속화
- 채팅 중 새로고침 시 메인(웰컴) 화면으로 돌아가던 문제 수정 — chatStore에 persist 미들웨어 추가, 새로고침해도 대화 내용(sessionId, messages) 유지
- 설정/관리자 화면에서 새로고침해도 채팅 화면으로 돌아가지 않도록 현재 화면(view)을 localStorage에 저장

## 🔗 관련 이슈
- #64 

## ✅ 체크리스트
- [x] 코드가 컨벤션을 따르고 있나요?
- [x] 불필요한 콘솔 로그를 제거했나요?
- [x] 커밋 메시지가 규칙을 따르고 있나요?

## 📸 스크린샷 (선택)
- 메인 화면
<img width="958" height="497" alt="스크린샷 2026-06-20 162230" src="https://github.com/user-attachments/assets/591ea85b-781e-4b55-b9ad-80b079f9c7ad" />

- 사이드바
<img width="955" height="494" alt="스크린샷 2026-06-20 162242" src="https://github.com/user-attachments/assets/c99f18d9-4865-49b3-b954-1a51e148ae17" />

- 채팅 화면
<img width="955" height="494" alt="스크린샷 2026-06-20 162322" src="https://github.com/user-attachments/assets/83621fdd-9883-4310-b44a-10c1a1002254" />

- 반응형 확인
<img width="371" height="490" alt="스크린샷 2026-06-20 162302" src="https://github.com/user-attachments/assets/1f33e03e-5e9d-419b-83eb-409a3731a855" />

- 공유 시 확인 토스트 메시지
<img width="956" height="496" alt="스크린샷 2026-06-20 163646" src="https://github.com/user-attachments/assets/fb57ed1c-e63e-4107-bae1-d854fb6274a5" />

- 채팅 답변 생성 중지
<img width="958" height="496" alt="스크린샷 2026-06-20 163658" src="https://github.com/user-attachments/assets/43a9001b-4ee5-430e-96b4-96fdf217c96b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 토스트 알림 추가
  * 현재 페이지 URL 공유 기능 추가
  * 대화 내용 및 뷰 상태 새로고침 후에도 유지

* **버그 수정**
  * 메시지 리스트 레이아웃 오버플로우 개선

* **스타일**
  * 입력창 안내 문구 개선
  * 중단된 메시지 상태 표시 추가
  * 사이드바 모바일 환경 UI 개선
  * 헤더 UI 정리

<!-- end of auto-generated comment: release notes by coderabbit.ai -->